### PR TITLE
566618 - Add ProducerCalculationResults: feeForCommsCostsWithBadDebtProvision_2b

### DIFF
--- a/src/EPR.Calculator.Service.Function.UnitTests/Exporter/JsonExporter/CalculationResults/CalculationResultsExporterTests.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Exporter/JsonExporter/CalculationResults/CalculationResultsExporterTests.cs
@@ -25,6 +25,7 @@
                 new CalcResultCommsCostByMaterial2AJsonMapper(),
                 new SAOperatingCostsWithBadDebtProvisionMapper(),
                 new FeeForCommsCostsWithBadDebtProvision2aMapper(),
+                new FeeForCommsCostsWithBadDebtProvision2bMapper(),
                 new TotalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper(),
                 new FeeForSASetUpCostsWithBadDebtProvision_5Mapper(),
                 new CalcResultCommsCostsWithBadDebtProvision2cMapper(),
@@ -300,6 +301,32 @@
             AssertAreEqual(producer.TotalProducerFeeforCommsCostsbyMaterialwoBadDebtprovision, twoACosts["totalProducerFeeForCommsCostsWithoutBadDebtProvision"]);
             AssertAreEqual(producer.BadDebtProvisionFor2A, twoACosts["badDebProvisionFor2a"]);
             AssertAreEqual(producer.TotalProducerFeeforCommsCostsbyMaterialwithBadDebtprovision, twoACosts["totalProducerFeeForCommsCostsWithBadDebtProvision"]);
+        }
+
+        [TestMethod]
+        public void Export_FeeForCommsCostsWithBadDebtProvision2b_AreValid()
+        {
+            // Arrange
+            var data = SetCalcResultSummayData();
+
+            // Act
+            var json = this.TestClass.Export(data, null, new List<int> { 1, 2, 3 });
+
+            var roundTrippedData = JsonSerializer.Deserialize<JsonObject>(json)!
+                ["calculationResults"]!
+                ["producerCalculationResults"];
+
+            // Assert
+            Assert.IsNotNull(roundTrippedData);
+            var twoBCosts = roundTrippedData[0]["feeForCommsCostsWithBadDebtProvision2b"];
+            var producer = data.ProducerDisposalFees.SingleOrDefault(t => !t.isTotalRow && !string.IsNullOrEmpty(t.Level));
+            AssertAreEqual(producer.NorthernIrelandTotalWithBadDebtFor2bComms, twoBCosts["northernIrelandTotalWithBadDebtProvision"]);
+            AssertAreEqual(producer.ScotlandTotalWithBadDebtFor2bComms, twoBCosts["scotlandTotalWithBadDebtProvision"]);
+            AssertAreEqual(producer.WalesTotalWithBadDebtFor2bComms, twoBCosts["walesTotalWithBadDebtProvision"]);
+            AssertAreEqual(producer.EnglandTotalWithBadDebtFor2bComms, twoBCosts["englandTotalWithBadDebtProvision"]);
+            AssertAreEqual(producer.TotalProducerFeeWithoutBadDebtFor2bComms, twoBCosts["totalProducerFeeForCommsCostsUKWideWithoutBadDebtProvision"]);
+            AssertAreEqual(producer.BadDebtProvisionFor2bComms, twoBCosts["badDebtProvisionFor2bComms"]);
+            AssertAreEqual(producer.TotalProducerFeeWithBadDebtFor2bComms, twoBCosts["totalProducerFeeForCommsCostsUKWideWithBadDebtProvision"]);
         }
 
         /// <summary>

--- a/src/EPR.Calculator.Service.Function.UnitTests/Mapper/FeeForCommsCostsWithBadDebtProvision2bMapperTests.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Mapper/FeeForCommsCostsWithBadDebtProvision2bMapperTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using AutoFixture;
+using EPR.Calculator.Service.Function.Mapper;
+using EPR.Calculator.Service.Function.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EPR.Calculator.Service.Function.UnitTests.Mapper
+{
+    [TestClass]
+    public class FeeForCommsCostsWithBadDebtProvision2bMapperTests
+    {
+        private FeeForCommsCostsWithBadDebtProvision2bMapper _testClass;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _testClass = new FeeForCommsCostsWithBadDebtProvision2bMapper();
+        }
+
+        [TestMethod]
+        public void CanCallMap()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var calcResultSummaryProducerDisposalFees = fixture.Create<CalcResultSummaryProducerDisposalFees>();
+
+            // Act
+            var result = _testClass.Map(calcResultSummaryProducerDisposalFees);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(result.TotalProducerFeeForCommsCostsUKWideWithoutBadDebtProvision, calcResultSummaryProducerDisposalFees.TotalProducerFeeWithoutBadDebtFor2bComms);
+            Assert.AreEqual(result.BadDebtProvisionFor2bComms, calcResultSummaryProducerDisposalFees.BadDebtProvisionFor2bComms);
+            Assert.AreEqual(result.TotalProducerFeeForCommsCostsUKWideWithBadDebtProvision, calcResultSummaryProducerDisposalFees.TotalProducerFeeWithBadDebtFor2bComms);
+            Assert.AreEqual(result.EnglandTotalWithBadDebtProvision, calcResultSummaryProducerDisposalFees.EnglandTotalWithBadDebtFor2bComms);
+            Assert.AreEqual(result.WalesTotalWithBadDebtProvision, calcResultSummaryProducerDisposalFees.WalesTotalWithBadDebtFor2bComms);
+            Assert.AreEqual(result.ScotlandTotalWithBadDebtProvision, calcResultSummaryProducerDisposalFees.ScotlandTotalWithBadDebtFor2bComms);
+            Assert.AreEqual(result.NorthernIrelandTotalWithBadDebtProvision, calcResultSummaryProducerDisposalFees.NorthernIrelandTotalWithBadDebtFor2bComms);
+        }
+    }
+}

--- a/src/EPR.Calculator.Service.Function.UnitTests/Models/JsonExporter/CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2bTests.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Models/JsonExporter/CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2bTests.cs
@@ -1,0 +1,80 @@
+﻿using AutoFixture;
+using EPR.Calculator.Service.Function.Models.JsonExporter;
+
+namespace EPR.Calculator.Service.Function.UnitTests.Models.JsonExporter
+{
+    [TestClass]
+    public class CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2bTests
+    {
+        private CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2b _testClass;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _testClass = new CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2b();
+        }
+
+        [TestMethod]
+        public void CanSetAndGetTotalProducerFeeForCommsCostsUKWideWithoutBadDebtProvision()
+        {
+            var fixture = new Fixture();
+            var testValue = fixture.Create<decimal>();
+            _testClass.TotalProducerFeeForCommsCostsUKWideWithoutBadDebtProvision = testValue;
+            Assert.AreEqual(testValue, _testClass.TotalProducerFeeForCommsCostsUKWideWithoutBadDebtProvision);
+        }
+
+        [TestMethod]
+        public void CanSetAndGetBadDebProvisionFor2b()
+        {
+            var fixture = new Fixture();
+            var testValue = fixture.Create<decimal>();
+            _testClass.BadDebtProvisionFor2bComms = testValue;
+            Assert.AreEqual(testValue, _testClass.BadDebtProvisionFor2bComms);
+        }
+
+        [TestMethod]
+        public void CanSetAndGetTotalProducerFeeForCommsCostsUKWideWithBadDebtProvision()
+        {
+            var fixture = new Fixture();
+            var testValue = fixture.Create<decimal>();
+            _testClass.TotalProducerFeeForCommsCostsUKWideWithBadDebtProvision = testValue;
+            Assert.AreEqual(testValue, _testClass.TotalProducerFeeForCommsCostsUKWideWithBadDebtProvision);
+        }
+
+        [TestMethod]
+        public void CanSetAndGetEnglandTotalWithBadDebtProvision()
+        {
+            var fixture = new Fixture();
+            var testValue = fixture.Create<decimal>();
+            _testClass.EnglandTotalWithBadDebtProvision = testValue;
+            Assert.AreEqual(testValue, _testClass.EnglandTotalWithBadDebtProvision);
+        }
+
+        [TestMethod]
+        public void CanSetAndGetWalesTotalWithBadDebtProvision()
+        {
+            var fixture = new Fixture();
+            var testValue = fixture.Create<decimal>();
+            _testClass.WalesTotalWithBadDebtProvision = testValue;
+            Assert.AreEqual(testValue, _testClass.WalesTotalWithBadDebtProvision);
+        }
+
+        [TestMethod]
+        public void CanSetAndGetScotlandTotalWithBadDebtProvision()
+        {
+            var fixture = new Fixture();
+            var testValue = fixture.Create<decimal>();
+            _testClass.ScotlandTotalWithBadDebtProvision = testValue;
+            Assert.AreEqual(testValue, _testClass.ScotlandTotalWithBadDebtProvision);
+        }
+
+        [TestMethod]
+        public void CanSetAndGetNorthernIrelandTotalWithBadDebtProvision()
+        {
+            var fixture = new Fixture();
+            var testValue = fixture.Create<decimal>();
+            _testClass.NorthernIrelandTotalWithBadDebtProvision = testValue;
+            Assert.AreEqual(testValue, _testClass.NorthernIrelandTotalWithBadDebtProvision);
+        }
+    }
+}

--- a/src/EPR.Calculator.Service.Function/Exporter/JsonExporter/CalculationResults/CalculationResultsExporter.cs
+++ b/src/EPR.Calculator.Service.Function/Exporter/JsonExporter/CalculationResults/CalculationResultsExporter.cs
@@ -21,6 +21,7 @@ namespace EPR.Calculator.Service.Function.Exporter.JsonExporter.CalcResult
         private readonly ICalcResultCommsCostByMaterial2AJsonMapper commsCostByMaterial2AJsonMapper;
         private readonly ISAOperatingCostsWithBadDebtProvisionMapper sAOperatingCostsWithBadDebtProvisionMapper;
         private readonly IFeeForCommsCostsWithBadDebtProvision2aMapper feeForCommsCostsWithBadDebtProvision2aMapper;
+        private readonly IFeeForCommsCostsWithBadDebtProvision2bMapper feeForCommsCostsWithBadDebtProvision2bMapper;
         private readonly ITotalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper totalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper;
         private readonly IFeeForSASetUpCostsWithBadDebtProvision_5Mapper feeForSASetUpCostsWithBadDebtProvision_5Mapper;
         private readonly ICalcResultCommsCostsWithBadDebtProvision2cMapper calcResultCommsCostsWithBadDebtProvision2CMapper;
@@ -33,6 +34,7 @@ namespace EPR.Calculator.Service.Function.Exporter.JsonExporter.CalcResult
             ICalcResultCommsCostByMaterial2AJsonMapper commsCostByMaterial2AJsonMapper,
             ISAOperatingCostsWithBadDebtProvisionMapper sAOperatingCostsWithBadDebtProvisionMapper,
             IFeeForCommsCostsWithBadDebtProvision2aMapper feeForCommsCostsWithBadDebtProvision2aMapper,
+            IFeeForCommsCostsWithBadDebtProvision2bMapper feeForCommsCostsWithBadDebtProvision2bMapper,
             ITotalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper totalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper,
             IFeeForSASetUpCostsWithBadDebtProvision_5Mapper feeForSASetUpCostsWithBadDebtProvision_5Mapper,
             ICalcResultCommsCostsWithBadDebtProvision2cMapper calcResultCommsCostsWithBadDebtProvision2CMapper,
@@ -43,6 +45,7 @@ namespace EPR.Calculator.Service.Function.Exporter.JsonExporter.CalcResult
             this.commsCostByMaterial2AJsonMapper = commsCostByMaterial2AJsonMapper;
             this.sAOperatingCostsWithBadDebtProvisionMapper = sAOperatingCostsWithBadDebtProvisionMapper;
             this.feeForCommsCostsWithBadDebtProvision2aMapper = feeForCommsCostsWithBadDebtProvision2aMapper;
+            this.feeForCommsCostsWithBadDebtProvision2bMapper = feeForCommsCostsWithBadDebtProvision2bMapper;
             this.totalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper = totalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper;
             this.feeForSASetUpCostsWithBadDebtProvision_5Mapper = feeForSASetUpCostsWithBadDebtProvision_5Mapper;
             this.calcResultCommsCostsWithBadDebtProvision2CMapper = calcResultCommsCostsWithBadDebtProvision2CMapper;
@@ -126,6 +129,7 @@ namespace EPR.Calculator.Service.Function.Exporter.JsonExporter.CalcResult
                     CalcResultCommsCostByMaterial2AJson = this.commsCostByMaterial2AJsonMapper.Map(producer.ProducerCommsFeesByMaterial!),
                     CalcResultSAOperatingCostsWithBadDebtProvision = this.sAOperatingCostsWithBadDebtProvisionMapper.Map(producer),
                     FeeForCommsCostsWithBadDebtProvision2a = this.feeForCommsCostsWithBadDebtProvision2aMapper.Map(producer),
+                    FeeForCommsCostsWithBadDebtProvision2b = this.feeForCommsCostsWithBadDebtProvision2bMapper.Map(producer),
                     CommsCostsByMaterialFeesSummary2a = this.commsCostsByMaterialFeesSummary2AMapper.Map(producer),
                     TotalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2c = this.totalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper.Map(producer),
                     FeeForSASetUpCostsWithBadDebtProvision_5 = this.feeForSASetUpCostsWithBadDebtProvision_5Mapper.Map(producer),

--- a/src/EPR.Calculator.Service.Function/Mapper/FeeForCommsCostsWithBadDebtProvision2bMapper.cs
+++ b/src/EPR.Calculator.Service.Function/Mapper/FeeForCommsCostsWithBadDebtProvision2bMapper.cs
@@ -1,0 +1,22 @@
+﻿using EPR.Calculator.Service.Function.Models;
+using EPR.Calculator.Service.Function.Models.JsonExporter;
+
+namespace EPR.Calculator.Service.Function.Mapper
+{
+    public class FeeForCommsCostsWithBadDebtProvision2bMapper : IFeeForCommsCostsWithBadDebtProvision2bMapper
+    {
+        public CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2b Map(CalcResultSummaryProducerDisposalFees source)
+        {
+            return new CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2b
+            {
+                TotalProducerFeeForCommsCostsUKWideWithoutBadDebtProvision = source.TotalProducerFeeWithoutBadDebtFor2bComms,
+                BadDebtProvisionFor2bComms = source.BadDebtProvisionFor2bComms,
+                TotalProducerFeeForCommsCostsUKWideWithBadDebtProvision = source.TotalProducerFeeWithBadDebtFor2bComms,
+                EnglandTotalWithBadDebtProvision = source.EnglandTotalWithBadDebtFor2bComms,
+                WalesTotalWithBadDebtProvision = source.WalesTotalWithBadDebtFor2bComms,
+                ScotlandTotalWithBadDebtProvision = source.ScotlandTotalWithBadDebtFor2bComms,
+                NorthernIrelandTotalWithBadDebtProvision = source.NorthernIrelandTotalWithBadDebtFor2bComms
+            };
+        }
+    }
+}

--- a/src/EPR.Calculator.Service.Function/Mapper/IFeeForCommsCostsWithBadDebtProvision2bMapper.cs
+++ b/src/EPR.Calculator.Service.Function/Mapper/IFeeForCommsCostsWithBadDebtProvision2bMapper.cs
@@ -1,0 +1,10 @@
+﻿using EPR.Calculator.Service.Function.Models;
+using EPR.Calculator.Service.Function.Models.JsonExporter;
+
+namespace EPR.Calculator.Service.Function.Mapper
+{
+    public interface IFeeForCommsCostsWithBadDebtProvision2bMapper
+    {
+        CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2b Map(CalcResultSummaryProducerDisposalFees calcResultSummaryProducerDisposalFees);
+    }
+}

--- a/src/EPR.Calculator.Service.Function/Models/JsonExporter/CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2b.cs
+++ b/src/EPR.Calculator.Service.Function/Models/JsonExporter/CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2b.cs
@@ -1,0 +1,36 @@
+﻿using EPR.Calculator.Service.Function.Converter;
+using Newtonsoft.Json;
+
+namespace EPR.Calculator.Service.Function.Models.JsonExporter
+{
+    public class CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2b
+    {
+        [JsonProperty(PropertyName = "totalProducerFeeForCommsCostsUKWideWithoutBadDebtProvision")]
+        [JsonConverter(typeof(DecimalPrecisionConverter), 3)]
+        public decimal TotalProducerFeeForCommsCostsUKWideWithoutBadDebtProvision { get; set; }
+
+        [JsonProperty(PropertyName = "badDebProvisionFor2b")]
+        [JsonConverter(typeof(DecimalPrecisionConverter), 3)]
+        public decimal BadDebtProvisionFor2bComms { get; set; }
+
+        [JsonProperty(PropertyName = "totalProducerFeeForCommsCostsUKWideWithBadDebtProvision")]
+        [JsonConverter(typeof(DecimalPrecisionConverter), 3)]
+        public decimal TotalProducerFeeForCommsCostsUKWideWithBadDebtProvision { get; set; }
+
+        [JsonProperty(PropertyName = "englandTotalWithBadDebtProvision")]
+        [JsonConverter(typeof(DecimalPrecisionConverter), 3)]
+        public decimal EnglandTotalWithBadDebtProvision { get; set; }
+
+        [JsonProperty(PropertyName = "walesTotalWithBadDebtProvision")]
+        [JsonConverter(typeof(DecimalPrecisionConverter), 3)]
+        public decimal WalesTotalWithBadDebtProvision { get; set; }
+
+        [JsonProperty(PropertyName = "scotlandTotalWithBadDebtProvision")]
+        [JsonConverter(typeof(DecimalPrecisionConverter), 3)]
+        public decimal ScotlandTotalWithBadDebtProvision { get; set; }
+
+        [JsonProperty(PropertyName = "northernIrelandTotalWithBadDebtProvision")]
+        [JsonConverter(typeof(DecimalPrecisionConverter), 3)]
+        public decimal NorthernIrelandTotalWithBadDebtProvision { get; set; }
+    }
+}

--- a/src/EPR.Calculator.Service.Function/Models/JsonExporter/CalcSummaryProducerCalculationResults.cs
+++ b/src/EPR.Calculator.Service.Function/Models/JsonExporter/CalcSummaryProducerCalculationResults.cs
@@ -12,6 +12,8 @@
 
         public required CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2a? FeeForCommsCostsWithBadDebtProvision2a { get; set; }
 
+        public required CalcResultSummaryFeeForCommsCostsWithBadDebtProvision2b? FeeForCommsCostsWithBadDebtProvision2b { get; set; }
+
         public required CalcResultsCommsCostsWithBadDebtProvision2c? FeeForCommsCostsWithBadDebtProvision2c { get; set; }
 
         public required TotalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2c TotalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2c { get; set; }

--- a/src/EPR.Calculator.Service.Function/Startup.cs
+++ b/src/EPR.Calculator.Service.Function/Startup.cs
@@ -147,6 +147,7 @@ namespace EPR.Calculator.Service.Function
             services.AddTransient<ICalcResultCommsCostByMaterial2AJsonExporter, CalcResultCommsCostByMaterial2AJsonExporter>();
             services.AddTransient<ISAOperatingCostsWithBadDebtProvisionMapper, SAOperatingCostsWithBadDebtProvisionMapper>();
             services.AddTransient<IFeeForCommsCostsWithBadDebtProvision2aMapper, FeeForCommsCostsWithBadDebtProvision2aMapper>();
+            services.AddTransient<IFeeForCommsCostsWithBadDebtProvision2bMapper, FeeForCommsCostsWithBadDebtProvision2bMapper>();
             services.AddTransient<ITotalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper, TotalProducerFeeWithBadDebtProvisibadDebProvisionFor2con_1_2a_2b_2cMapper>();
             services.AddTransient<IFeeForSASetUpCostsWithBadDebtProvision_5Mapper, FeeForSASetUpCostsWithBadDebtProvision_5Mapper>();
             services.AddTransient<ICalcResultCommsCostsWithBadDebtProvision2cMapper, CalcResultCommsCostsWithBadDebtProvision2cMapper>();


### PR DESCRIPTION
This PR adds the feeForCommsCostsWithBadDebtProvision_2b section. 

![image](https://github.com/user-attachments/assets/dbce2f0d-c907-4a72-9aa4-fc13a5a8ea7e)
