### PR TITLE
576803 JSON Billing File - Differences in  'Scaled-up Producers' sect…

### DIFF
--- a/src/EPR.Calculator.Service.Function.UnitTests/Converter/DecimalPrecisionConverterTests.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Converter/DecimalPrecisionConverterTests.cs
@@ -1,6 +1,8 @@
 namespace EPR.Calculator.Service.Function.UnitTests.Converter
 {
     using System;
+    using System.Text;
+    using System.Text.Json;
     using AutoFixture;
     using EPR.Calculator.Service.Function.Converter;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,12 +17,13 @@ namespace EPR.Calculator.Service.Function.UnitTests.Converter
             // Act
             var converter = new DecimalPrecisionConverter(3);
             var val = 123.9879908m;
-            var stringWriter =  new StringWriter();
-            var jsonWriter = new JsonTextWriter(stringWriter);
+            var stream = new MemoryStream();
+            var jsonWriter = new Utf8JsonWriter(stream);
 
-            converter.WriteJson(jsonWriter, val, new JsonSerializer());
+            converter.Write(jsonWriter, val, new JsonSerializerOptions { });
             jsonWriter.Flush();
-            var result = stringWriter.ToString();
+            stream.Position = 0;
+            var result = new StreamReader(stream).ReadToEnd();
 
             // Assert
             Assert.AreEqual("123.988",result);
@@ -32,11 +35,11 @@ namespace EPR.Calculator.Service.Function.UnitTests.Converter
             // Act
             var converter = new DecimalPrecisionConverter(3);
             var json = "\"123.988\"";
-            var stringReader = new StringReader(json);
-            var jsonReader = new JsonTextReader(stringReader);
+            var bytes = Encoding.UTF8.GetBytes(json);
+            var jsonReader = new Utf8JsonReader(bytes);
 
             jsonReader.Read();
-            var result = converter.ReadJson(jsonReader, typeof(decimal), null, new JsonSerializer());
+            var result = converter.Read(ref jsonReader, typeof(decimal), new JsonSerializerOptions { });
 
             // Assert
             Assert.AreEqual(123.988m, result);

--- a/src/EPR.Calculator.Service.Function/Exporter/JsonExporter/CalcResultsJsonExporter.cs
+++ b/src/EPR.Calculator.Service.Function/Exporter/JsonExporter/CalcResultsJsonExporter.cs
@@ -5,6 +5,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Unicode;
 using EPR.Calculator.API.Exporter;
+using EPR.Calculator.Service.Function.Converter;
 using EPR.Calculator.Service.Function.Exporter.JsonExporter.CalculationResults;
 using EPR.Calculator.Service.Function.Exporter.JsonExporter.CancelledProducersData;
 using EPR.Calculator.Service.Function.Exporter.JsonExporter.CommsCostByMaterial2A;
@@ -22,6 +23,8 @@ namespace EPR.Calculator.Service.Function.Exporter.JsonExporter
 {
     public class CalcResultsJsonExporter : ICalcBillingJsonExporter<CalcResult>
     {
+        private const int decimalPrecision = 3;
+
         private readonly IMaterialService materialService;
         private readonly ICalcResultDetailJsonExporter calcResultDetailExporter;
         private readonly ICalcResultLapcapExporter lapcapExporter;
@@ -99,6 +102,7 @@ namespace EPR.Calculator.Service.Function.Exporter.JsonExporter
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                     WriteIndented = true,
                     Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                    Converters = { new DecimalPrecisionConverter(decimalPrecision), },
                 });
         }
     }

--- a/src/EPR.Calculator.Service.Function/Exporter/JsonExporter/CommsCostByMaterial2A/CalcResultCommsCostByMaterial2AJsonExporter.cs
+++ b/src/EPR.Calculator.Service.Function/Exporter/JsonExporter/CommsCostByMaterial2A/CalcResultCommsCostByMaterial2AJsonExporter.cs
@@ -1,7 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using EPR.Calculator.Service.Function.Mapper;
 using EPR.Calculator.Service.Function.Models;
-using Newtonsoft.Json;
 
 namespace EPR.Calculator.Service.Function.Exporter.JsonExporter.CommsCostByMaterial2A
 {
@@ -17,7 +18,7 @@ namespace EPR.Calculator.Service.Function.Exporter.JsonExporter.CommsCostByMater
         public string Export(Dictionary<string, CalcResultSummaryProducerCommsFeesCostByMaterial> commsCostByMaterial, List<MaterialDetail> materials)
         {
             var result = this.mapper.Map(commsCostByMaterial, materials);
-            return JsonConvert.SerializeObject(result);
+            return JsonSerializer.Serialize(result);
         }
     }
 }

--- a/src/EPR.Calculator.Service.Function/Mapper/CalcResultScaledupProducersJsonMapper.cs
+++ b/src/EPR.Calculator.Service.Function/Mapper/CalcResultScaledupProducersJsonMapper.cs
@@ -76,16 +76,16 @@ namespace EPR.Calculator.Service.Function.Mapper
                 var breakdown = new MaterialBreakdown
                 {
                     MaterialName = material.Name,
-                    ReportedHouseholdPackagingWasteTonnage = Math.Round(producerTonnage.Value.ReportedHouseholdPackagingWasteTonnage, 3),
-                    ReportedPublicBinTonnage = Math.Round(producerTonnage.Value.ReportedPublicBinTonnage, 3),
-                    TotalReportedTonnage = Math.Round(producerTonnage.Value.TotalReportedTonnage, 3),
-                    ReportedSelfManagedConsumerWasteTonnage = Math.Round(producerTonnage.Value.ReportedSelfManagedConsumerWasteTonnage, 3),
-                    NetReportedTonnage = Math.Round(producerTonnage.Value.NetReportedTonnage, 3),
-                    ScaledUpReportedHouseholdPackagingWasteTonnage = Math.Round(producerTonnage.Value.ScaledupReportedHouseholdPackagingWasteTonnage, 3),
-                    ScaledUpReportedPublicBinTonnage = Math.Round(producerTonnage.Value.ScaledupReportedPublicBinTonnage, 3),
-                    ScaledUpTotalReportedTonnage = Math.Round(producerTonnage.Value.ScaledupTotalReportedTonnage, 3),
-                    ScaledUpReportedSelfManagedConsumerWasteTonnage = Math.Round(producerTonnage.Value.ScaledupReportedSelfManagedConsumerWasteTonnage, 3),
-                    ScaledUpNetReportedTonnage = Math.Round(producerTonnage.Value.ScaledupNetReportedTonnage, 3)
+                    ReportedHouseholdPackagingWasteTonnage = producerTonnage.Value.ReportedHouseholdPackagingWasteTonnage,
+                    ReportedPublicBinTonnage = producerTonnage.Value.ReportedPublicBinTonnage,
+                    TotalReportedTonnage = producerTonnage.Value.TotalReportedTonnage,
+                    ReportedSelfManagedConsumerWasteTonnage = producerTonnage.Value.ReportedSelfManagedConsumerWasteTonnage,
+                    NetReportedTonnage = producerTonnage.Value.NetReportedTonnage,
+                    ScaledUpReportedHouseholdPackagingWasteTonnage = producerTonnage.Value.ScaledupReportedHouseholdPackagingWasteTonnage,
+                    ScaledUpReportedPublicBinTonnage = producerTonnage.Value.ScaledupReportedPublicBinTonnage,
+                    ScaledUpTotalReportedTonnage = producerTonnage.Value.ScaledupTotalReportedTonnage,
+                    ScaledUpReportedSelfManagedConsumerWasteTonnage = producerTonnage.Value.ScaledupReportedSelfManagedConsumerWasteTonnage,
+                    ScaledUpNetReportedTonnage = producerTonnage.Value.ScaledupNetReportedTonnage,
                 };
 
                 if (producerTonnage.Key == MaterialCodes.Glass)


### PR DESCRIPTION
…ion (#202)

* 576735 Json exporter producer disposal fees (#193)

* Fix property name (#194)

* Fix for 576579 -calcResultLaDisposalCostData  and one minor fix for bug 576558 as well (#199)



* 576876 json exporter billing instructions fix (#198)

* Update CalculationOfSuggestedBillingInstructionsAndInvoiceAmounts.cs

* 576876 Json exporter billing instructions fix

* Fix header record being output instead of data (#196)



* Bug/576759  special charecters json (#200)

* update json settings

* fixed the level format issue in json

* fix the csv total for scaled up producers

* Fix precision when writing decimals to JSON

(cherry picked from commit e05bec0e71adae4f6fc696ee4dd7d3b853cbf2d0)

* 576762 differences in scaled up producers section (#203)

* Fix Differences in  'Scaled-up Producers' section

* Remove newtonsoft

---------