### PR TITLE
Feature/ecv 512

### DIFF
--- a/src/EPR.Calculator.Service.Common.UnitTests/EPR.Calculator.Service.Common.UnitTests.csproj
+++ b/src/EPR.Calculator.Service.Common.UnitTests/EPR.Calculator.Service.Common.UnitTests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="EPR.Calculator.API.Data" Version="2.3.0"/>
+    <PackageReference Include="EPR.Calculator.API.Data" Version="2.4.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
     <PackageReference Include="Moq" Version="4.20.72"/>
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1"/>

--- a/src/EPR.Calculator.Service.Common/EPR.Calculator.Service.Common.csproj
+++ b/src/EPR.Calculator.Service.Common/EPR.Calculator.Service.Common.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Analytics.Synapse.Artifacts" Version="1.0.0-preview.20"/>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0"/>
-    <PackageReference Include="EPR.Calculator.API.Data" Version="2.3.0"/>
+    <PackageReference Include="EPR.Calculator.API.Data" Version="2.4.0"/>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1"/>
   </ItemGroup>
 

--- a/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/CalcResultProjectedProducersBuilderTest.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/CalcResultProjectedProducersBuilderTest.cs
@@ -266,6 +266,27 @@ namespace EPR.Calculator.Service.Function.UnitTests.Builder.ProjectedProducers
             AssertExcepted(expected, await FillGaps(given));
         }
 
+        [TestMethod]
+        public async Task H1H2Projection_h1_use_subtotal_h2_projection()
+        {
+            var given = new[] {
+                new[] { "101", "", "2025-H2", "", "AL", "HH", "100", "20",  "40", "40",  "0",  "", "" },
+                new[] { "101", "A", "2025-H2", "", "AL", "HH", "200", "20",  "40", "40",  "0",  "", "" },
+                new[] { "101", "B", "2025-H2", "", "AL", "HH", "300", "150", "25", "25",  "0",  "", "" },
+                new[] { "101", "", "2025-H1", "", "AL", "HH", "100", "20",  "40", "40",  "0",  "", "" },
+                new[] { "101", "A", "2025-H2", "", "AL", "HH", "200", "20",  "40", "40",  "0",  "", "" },
+                new[] { "101", "B", "2025-H2", "", "AL", "HH", "300", "150", "25", "25",  "0",  "", "" },
+            };
+            var expected = new[]  {
+                new[] { "101", "", "2025-H1", "1", "AL", "HH", "100", "20.000", "40.000", "40.000", "0", "0", "0" },
+                new[] { "101", "", "2025-H2", "1", "AL", "HH", "1100", "760", "170", "170", "0", "0", "0" },
+                new[] { "101", "", "2025-H2", "2", "AL", "HH", "100", "20", "40", "40", "0", "0", "0" },
+                new[] { "101", "A", "2025-H2", "2", "AL", "HH", "400", "240", "80", "80", "0", "0", "0" },
+                new[] { "101", "B", "2025-H2", "2", "AL", "HH", "600", "500", "50", "50", "0", "0", "0" }
+            };
+            AssertExcepted(expected, await FillGaps(given));
+        }
+
         private CalcResultsRequestDto InsertData(string[][] given)
         {
             for (int i = 0; i < given.GetLength(0); i++)

--- a/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/CalcResultProjectedProducersBuilderTest.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/CalcResultProjectedProducersBuilderTest.cs
@@ -17,10 +17,6 @@ namespace EPR.Calculator.Service.Function.UnitTests.Builder.ProjectedProducers
     using Microsoft.EntityFrameworkCore.Diagnostics;
     using static EPR.Calculator.Service.Function.UnitTests.Builder.CalcRunLaDisposalCostBuilderTests;
 
-    using System.Linq;
-    using System.Runtime.InteropServices;
-    using EPR.Calculator.Service.Function.Models.JsonExporter;
-
     [TestClass]
     public class CalcResultProjectedProducersBuilderTest
     {
@@ -69,41 +65,50 @@ namespace EPR.Calculator.Service.Function.UnitTests.Builder.ProjectedProducers
         [TestMethod]
         public async Task H1H2Projection_untouched()
         {
-            // RAM is complete - no modifications made
+            // RAM is complete - no modifications needed and therefore they do not appear
             var given = new[] {
                 new[] { "101", "", "2025-H1", "", "AL", "HH", "100", "20", "40", "40", "0", "", "" },
                 new[] { "101", "", "2025-H2", "", "AL", "HH", "100", "20", "40", "40", "0", "", "" }
             };
-            var expected = new [] {
-                new[] { "101", "", "2025-H1", "1", "AL", "HH", "100", "20.0", "40.0", "40.0", "0", "0", "0" },
-                new[] { "101", "", "2025-H2", "1", "AL", "HH", "100", "20", "40", "40", "0", "0", "0" }
-            };
+            var expected = Array.Empty<string[]>();
             AssertExcepted(expected, await FillGaps(given));
         }
-
+        
         [TestMethod]
         public async Task H1H2Projection_untouched_onlyh2()
         {
-            // RAM is complete - only H2 - no modifications made
+            // RAM is complete - only H2 - no modifications needed and therefore they do not appear
             var given = new[] {
                 new[] { "101", "", "2025-H2", "", "AL", "HH", "100", "30", "40", "40", "0", "", "" }
             };
-            var expected = new [] {
-                new[] { "101", "", "2025-H2", "1", "AL", "HH", "100", "30", "40", "40", "0", "0", "0" }
-            };
+            var expected = Array.Empty<string[]>();
             AssertExcepted(expected, await FillGaps(given));
         }
 
         [TestMethod]
         public async Task H1H2Projection_untouched_onlyh1()
         {
-            // RAM is complete - only H1 - no modifications made
+            // RAM is complete - only H1 - no modifications needed and therefore they do not appear
             var given = new[] {
                 new[] { "101", "", "2025-H1", "", "AL", "HH", "100", "30", "40", "40", "0", "", "" }
             };
-            var expected = new [] {
-                new[] { "101", "", "2025-H1", "1", "AL", "HH", "100", "30", "40", "40", "0", "0", "0" }
+            var expected = Array.Empty<string[]>();
+            AssertExcepted(expected, await FillGaps(given));
+        }
+
+        [TestMethod]
+        public async Task H1H2Projection_untouched_hc()
+        {
+            // RAM is complete - no modifications needed and therefore they do not appear
+            var given = new[] {
+                new[] { "101", "", "2025-H1", "", "AL", "HH", "100", "20", "40", "40", "0", "", "" },
+                new[] { "101", "A", "2025-H1", "", "GL", "HDC", "100", "20", "40", "40", "0", "", "" },
+                new[] { "101", "B", "2025-H1", "", "AL", "PB", "100", "20", "40", "40", "0", "", "" },
+                new[] { "101", "", "2025-H2", "", "PL", "HH", "100", "20", "40", "40", "0", "", "" },
+                new[] { "101", "A", "2025-H2", "", "ST", "PB", "100", "20", "40", "40", "0", "", "" },
+                new[] { "101", "B", "2025-H2", "", "AL", "HH", "100", "20", "40", "40", "0", "", "" }
             };
+            var expected = Array.Empty<string[]>();
             AssertExcepted(expected, await FillGaps(given));
         }
 
@@ -243,7 +248,7 @@ namespace EPR.Calculator.Service.Function.UnitTests.Builder.ProjectedProducers
         {
             // Part of holding group where holding group doesn't report for themselves - different materials
             var given = new[] {
-                new[] { "101", "A", "2025-H1", "", "ST", "HH", "100", "20",  "40", "40",  "0",  "", "" },
+                new[] { "101", "A", "2025-H1", "", "ST", "HH", "100", "20",  "20", "40",  "0",  "", "" },
                 new[] { "101", "A", "2025-H2", "", "AL", "HH", "100", "20",  "40", "40",  "0",  "", "" },
                 new[] { "101", "A", "2025-H1", "", "PL", "PB", "100", "20",  "40", "40",  "0",  "", "" },
                 new[] { "101", "A", "2025-H2", "", "PL", "PB", "100", "20",  "40", "40",  "0",  "", "" },
@@ -252,9 +257,9 @@ namespace EPR.Calculator.Service.Function.UnitTests.Builder.ProjectedProducers
             };
             var expected = new[]  {
                 new[] { "101", "",  "2025-H1", "1", "PL", "PB", "100", "20.0", "40.0", "40.0", "0", "0", "0" },
-                new[] { "101", "",  "2025-H1", "1", "ST", "HH", "300", "70",   "90",   "140",  "0", "0", "0" },
+                new[] { "101", "",  "2025-H1", "1", "ST", "HH", "300", "90",   "70",   "140",  "0", "0", "0" },
                 new[] { "101", "A", "2025-H1", "2", "PL", "PB", "100", "20.0", "40.0", "40.0", "0", "0", "0" },
-                new[] { "101", "A", "2025-H1", "2", "ST", "HH", "100", "20",   "40",   "40",   "0", "0", "0" },
+                new[] { "101", "A", "2025-H1", "2", "ST", "HH", "100", "40",   "20",   "40",   "0", "0", "0" },
                 new[] { "101", "B", "2025-H1", "2", "ST", "HH", "200", "50",   "50",   "100",  "0", "0", "0" },
 
                 new[] { "101", "",  "2025-H2", "1", "AL", "HH", "300", "170",  "65",   "65",   "0", "0", "0" },

--- a/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/CalcResultProjectedProducersBuilderTest.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/CalcResultProjectedProducersBuilderTest.cs
@@ -65,41 +65,48 @@ namespace EPR.Calculator.Service.Function.UnitTests.Builder.ProjectedProducers
         [TestMethod]
         public async Task H1H2Projection_untouched()
         {
-            // RAM is complete - no modifications needed and therefore they do not appear
+            // RAM is complete - no modifications made
             var given = new[] {
                 new[] { "101", "", "2025-H1", "", "AL", "HH", "100", "20", "40", "40", "0", "", "" },
                 new[] { "101", "", "2025-H2", "", "AL", "HH", "100", "20", "40", "40", "0", "", "" }
             };
-            var expected = Array.Empty<string[]>();
+            var expected = new [] {
+                new[] { "101", "", "2025-H1", "1", "AL", "HH", "100", "20.0", "40.0", "40.0", "0", "0", "0" },
+                new[] { "101", "", "2025-H2", "1", "AL", "HH", "100", "20", "40", "40", "0", "0", "0" }
+            };
             AssertExcepted(expected, await FillGaps(given));
         }
         
         [TestMethod]
         public async Task H1H2Projection_untouched_onlyh2()
         {
-            // RAM is complete - only H2 - no modifications needed and therefore they do not appear
+            // RAM is complete - only H2 - no modifications made
             var given = new[] {
                 new[] { "101", "", "2025-H2", "", "AL", "HH", "100", "30", "40", "40", "0", "", "" }
             };
-            var expected = Array.Empty<string[]>();
+            var expected = new [] {
+                new[] { "101", "", "2025-H2", "1", "AL", "HH", "100", "30", "40", "40", "0", "0", "0" }
+            };
             AssertExcepted(expected, await FillGaps(given));
         }
 
         [TestMethod]
         public async Task H1H2Projection_untouched_onlyh1()
         {
-            // RAM is complete - only H1 - no modifications needed and therefore they do not appear
+            // RAM is complete - only H1 - no modifications made
             var given = new[] {
                 new[] { "101", "", "2025-H1", "", "AL", "HH", "100", "30", "40", "40", "0", "", "" }
             };
-            var expected = Array.Empty<string[]>();
+            var expected = new [] {
+                new[] { "101", "", "2025-H1", "1", "AL", "HH", "100", "30", "40", "40", "0", "0", "0" }
+            };
             AssertExcepted(expected, await FillGaps(given));
         }
 
         [TestMethod]
         public async Task H1H2Projection_untouched_hc()
         {
-            // RAM is complete - no modifications needed and therefore they do not appear
+            // RAM is complete - no modifications made
             var given = new[] {
                 new[] { "101", "", "2025-H1", "", "AL", "HH", "100", "20", "40", "40", "0", "", "" },
                 new[] { "101", "A", "2025-H1", "", "GL", "HDC", "100", "20", "40", "40", "0", "", "" },
@@ -108,7 +115,21 @@ namespace EPR.Calculator.Service.Function.UnitTests.Builder.ProjectedProducers
                 new[] { "101", "A", "2025-H2", "", "ST", "PB", "100", "20", "40", "40", "0", "", "" },
                 new[] { "101", "B", "2025-H2", "", "AL", "HH", "100", "20", "40", "40", "0", "", "" }
             };
-            var expected = Array.Empty<string[]>();
+            var expected = new string[][]
+            {
+                new string[] { "101", "", "2025-H1", "1", "AL", "HH", "100", "20.0", "40.0", "40.0", "0", "0", "0" },
+                new string[] { "101", "", "2025-H1", "1", "AL", "PB", "100", "20.0", "40.0", "40.0", "0", "0", "0" },
+                new string[] { "101", "", "2025-H1", "1", "GL", "HDC", "100", "20", "40", "40", "0", "0", "0" },
+                new string[] { "101", "", "2025-H1", "2", "AL", "HH", "100", "20.0", "40.0", "40.0", "0", "0", "0" },
+                new string[] { "101", "B", "2025-H1", "2", "AL", "PB", "100", "20.0", "40.0", "40.0", "0", "0", "0" },
+                new string[] { "101", "A", "2025-H1", "2", "GL", "HDC", "100", "20", "40", "40", "0", "0", "0" },
+                new string[] { "101", "", "2025-H2", "1", "AL", "HH", "100", "20", "40", "40", "0", "0", "0" },
+                new string[] { "101", "", "2025-H2", "1", "PL", "HH", "100", "20", "40", "40", "0", "0", "0" },
+                new string[] { "101", "", "2025-H2", "1", "ST", "PB", "100", "20", "40", "40", "0", "0", "0" },
+                new string[] { "101", "", "2025-H2", "2", "PL", "HH", "100", "20", "40", "40", "0", "0", "0" },
+                new string[] { "101", "B", "2025-H2", "2", "AL", "HH", "100", "20", "40", "40", "0", "0", "0" },
+                new string[] { "101", "A", "2025-H2", "2", "ST", "PB", "100", "20", "40", "40", "0", "0", "0" }
+            };
             AssertExcepted(expected, await FillGaps(given));
         }
 

--- a/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/H1ProjectedProducersBuilderUtilsTest.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/H1ProjectedProducersBuilderUtilsTest.cs
@@ -378,6 +378,83 @@
         } 
 
         [TestMethod]
+        public void GetProjectedProducers_Use_HC_Subtotal_H2_Proportions()
+        {
+            var (h1HHAlm, h1HdcGlass, subH1HHAlm, subH1HdcGlass, h1NoRamReportedMaterials) = GetH1NoRamReportedMaterialsWithSubsidiary();
+            var (h2SubtotalAlm, h2SubtotalGlass, h2FullRamProjectedProducers) = GetH2WithHCSubtotal();
+            var result = H1ProjectedProducersBuilderUtils.GetProjectedProducers(h1NoRamReportedMaterials, h2FullRamProjectedProducers, materials);
+
+            Assert.AreEqual(2, result.Count());
+            var hc = result.Where(p => p.ProducerId == 11 && p.SubsidiaryId == null).FirstOrDefault();
+            var sub = result.Where(p => p.ProducerId == 11 && p.SubsidiaryId == "A").FirstOrDefault();
+            Assert.IsNotNull(hc);
+            Assert.IsNotNull(sub);
+            Assert.AreEqual(3, hc.H1ProjectedTonnageByMaterial.Count());
+            Assert.AreEqual(3, sub.H1ProjectedTonnageByMaterial.Count());
+
+            var projectedHCAluminium = hc.H1ProjectedTonnageByMaterial[MaterialCodes.Aluminium];
+            var projectedHCGlass = hc.H1ProjectedTonnageByMaterial[MaterialCodes.Glass];
+            var projectedSubAluminium = sub.H1ProjectedTonnageByMaterial[MaterialCodes.Aluminium];
+            var projectedSubGlass = sub.H1ProjectedTonnageByMaterial[MaterialCodes.Glass];
+
+            var expAlmH2SubtotalProportions = new RAMProportions{
+                Red = To6DP((h2SubtotalAlm.ProjectedHouseholdRAMTonnage.RedTonnage + h2SubtotalAlm.ProjectedPublicBinRAMTonnage.RedTonnage) / h2SubtotalAlm.TotalTonnage),
+                Amber = To6DP((h2SubtotalAlm.ProjectedHouseholdRAMTonnage.AmberTonnage + h2SubtotalAlm.ProjectedPublicBinRAMTonnage.AmberTonnage) / h2SubtotalAlm.TotalTonnage),
+                Green = To6DP((h2SubtotalAlm.ProjectedHouseholdRAMTonnage.GreenTonnage + h2SubtotalAlm.ProjectedPublicBinRAMTonnage.GreenTonnage) / h2SubtotalAlm.TotalTonnage),
+                RedMedical = To6DP((h2SubtotalAlm.ProjectedHouseholdRAMTonnage.RedMedicalTonnage + h2SubtotalAlm.ProjectedPublicBinRAMTonnage.RedMedicalTonnage) / h2SubtotalAlm.TotalTonnage),
+                AmberMedical = To6DP((h2SubtotalAlm.ProjectedHouseholdRAMTonnage.AmberMedicalTonnage + h2SubtotalAlm.ProjectedPublicBinRAMTonnage.AmberMedicalTonnage) / h2SubtotalAlm.TotalTonnage),
+                GreenMedical = To6DP((h2SubtotalAlm.ProjectedHouseholdRAMTonnage.GreenMedicalTonnage + h2SubtotalAlm.ProjectedPublicBinRAMTonnage.GreenMedicalTonnage) / h2SubtotalAlm.TotalTonnage)
+            };
+
+            var expGlassH2SubtotalProportions = new RAMProportions{
+                Red = To6DP((h2SubtotalGlass.ProjectedHouseholdRAMTonnage.RedTonnage + h2SubtotalGlass.ProjectedPublicBinRAMTonnage.RedTonnage + (h2SubtotalGlass.ProjectedHouseholdDrinksContainerRAMTonnage?.RedTonnage ?? 0)) / h2SubtotalGlass.TotalTonnage),
+                Amber = To6DP((h2SubtotalGlass.ProjectedHouseholdRAMTonnage.AmberTonnage + h2SubtotalGlass.ProjectedPublicBinRAMTonnage.AmberTonnage + (h2SubtotalGlass.ProjectedHouseholdDrinksContainerRAMTonnage?.AmberTonnage ?? 0)) / h2SubtotalGlass.TotalTonnage),
+                Green = To6DP((h2SubtotalGlass.ProjectedHouseholdRAMTonnage.GreenTonnage + h2SubtotalGlass.ProjectedPublicBinRAMTonnage.GreenTonnage + (h2SubtotalGlass.ProjectedHouseholdDrinksContainerRAMTonnage?.GreenTonnage ?? 0)) / h2SubtotalGlass.TotalTonnage),
+                RedMedical = To6DP((h2SubtotalGlass.ProjectedHouseholdRAMTonnage.RedMedicalTonnage + h2SubtotalGlass.ProjectedPublicBinRAMTonnage.RedMedicalTonnage + (h2SubtotalGlass.ProjectedHouseholdDrinksContainerRAMTonnage?.RedMedicalTonnage ?? 0)) / h2SubtotalGlass.TotalTonnage),
+                AmberMedical = To6DP((h2SubtotalGlass.ProjectedHouseholdRAMTonnage.AmberMedicalTonnage + h2SubtotalGlass.ProjectedPublicBinRAMTonnage.AmberMedicalTonnage + (h2SubtotalGlass.ProjectedHouseholdDrinksContainerRAMTonnage?.AmberMedicalTonnage ?? 0)) / h2SubtotalGlass.TotalTonnage),
+                GreenMedical = To6DP((h2SubtotalGlass.ProjectedHouseholdRAMTonnage.GreenMedicalTonnage + h2SubtotalGlass.ProjectedPublicBinRAMTonnage.GreenMedicalTonnage + (h2SubtotalGlass.ProjectedHouseholdDrinksContainerRAMTonnage?.GreenMedicalTonnage ?? 0)) / h2SubtotalGlass.TotalTonnage)
+            };
+
+            //H2 proportions for HC and Sub should be the same - i.e. using the subtotal proproptions
+            Assert.AreEqual(expAlmH2SubtotalProportions, projectedHCAluminium.H2RamProportions);
+            Assert.AreEqual(expAlmH2SubtotalProportions, projectedSubAluminium.H2RamProportions);
+            Assert.AreEqual(expGlassH2SubtotalProportions, projectedHCGlass.H2RamProportions);
+            Assert.AreEqual(expGlassH2SubtotalProportions, projectedSubGlass.H2RamProportions);
+
+            Assert.AreEqual(h1HHAlm.PackagingTonnage, projectedHCAluminium.ProjectedHouseholdRAMTonnage.Tonnage);
+            AssertWithin(To3DP(h1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.Red), projectedHCAluminium.ProjectedHouseholdRAMTonnage.RedTonnage);
+            AssertWithin(To3DP(h1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.Amber), projectedHCAluminium.ProjectedHouseholdRAMTonnage.AmberTonnage);
+            AssertWithin(To3DP(h1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.Green), projectedHCAluminium.ProjectedHouseholdRAMTonnage.GreenTonnage);
+            AssertWithin(To3DP(h1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.RedMedical), projectedHCAluminium.ProjectedHouseholdRAMTonnage.RedMedicalTonnage);
+            AssertWithin(To3DP(h1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.AmberMedical), projectedHCAluminium.ProjectedHouseholdRAMTonnage.AmberMedicalTonnage);
+            AssertWithin(To3DP(h1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.GreenMedical), projectedHCAluminium.ProjectedHouseholdRAMTonnage.GreenMedicalTonnage);
+
+            Assert.AreEqual(h1HdcGlass.PackagingTonnage, projectedHCGlass.ProjectedHouseholdDrinksContainerRAMTonnage!.Tonnage);
+            AssertWithin(To3DP(h1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.Red), projectedHCGlass.ProjectedHouseholdDrinksContainerRAMTonnage.RedTonnage);
+            AssertWithin(To3DP(h1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.Amber), projectedHCGlass.ProjectedHouseholdDrinksContainerRAMTonnage.AmberTonnage);
+            AssertWithin(To3DP(h1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.Green), projectedHCGlass.ProjectedHouseholdDrinksContainerRAMTonnage.GreenTonnage);
+            AssertWithin(To3DP(h1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.RedMedical), projectedHCGlass.ProjectedHouseholdDrinksContainerRAMTonnage.RedMedicalTonnage);
+            AssertWithin(To3DP(h1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.AmberMedical), projectedHCGlass.ProjectedHouseholdDrinksContainerRAMTonnage.AmberMedicalTonnage);
+            AssertWithin(To3DP(h1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.GreenMedical), projectedHCGlass.ProjectedHouseholdDrinksContainerRAMTonnage.GreenMedicalTonnage);
+
+            Assert.AreEqual(subH1HHAlm.PackagingTonnage, projectedSubAluminium.ProjectedHouseholdRAMTonnage.Tonnage);
+            AssertWithin(To3DP(subH1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.Red), projectedSubAluminium.ProjectedHouseholdRAMTonnage.RedTonnage);
+            AssertWithin(To3DP(subH1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.Amber), projectedSubAluminium.ProjectedHouseholdRAMTonnage.AmberTonnage);
+            AssertWithin(To3DP(subH1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.Green), projectedSubAluminium.ProjectedHouseholdRAMTonnage.GreenTonnage);
+            AssertWithin(To3DP(subH1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.RedMedical), projectedSubAluminium.ProjectedHouseholdRAMTonnage.RedMedicalTonnage);
+            AssertWithin(To3DP(subH1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.AmberMedical), projectedSubAluminium.ProjectedHouseholdRAMTonnage.AmberMedicalTonnage);
+            AssertWithin(To3DP(subH1HHAlm.PackagingTonnage * expAlmH2SubtotalProportions.GreenMedical), projectedSubAluminium.ProjectedHouseholdRAMTonnage.GreenMedicalTonnage);
+
+            Assert.AreEqual(subH1HdcGlass.PackagingTonnage, projectedSubGlass.ProjectedHouseholdDrinksContainerRAMTonnage!.Tonnage);
+            AssertWithin(To3DP(subH1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.Red), projectedSubGlass.ProjectedHouseholdDrinksContainerRAMTonnage!.RedTonnage);
+            AssertWithin(To3DP(subH1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.Amber), projectedSubGlass.ProjectedHouseholdDrinksContainerRAMTonnage!.AmberTonnage);
+            AssertWithin(To3DP(subH1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.Green), projectedSubGlass.ProjectedHouseholdDrinksContainerRAMTonnage!.GreenTonnage);
+            AssertWithin(To3DP(subH1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.RedMedical), projectedSubGlass.ProjectedHouseholdDrinksContainerRAMTonnage!.RedMedicalTonnage);
+            AssertWithin(To3DP(subH1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.AmberMedical), projectedSubGlass.ProjectedHouseholdDrinksContainerRAMTonnage!.AmberMedicalTonnage);
+            AssertWithin(To3DP(subH1HdcGlass.PackagingTonnage * expGlassH2SubtotalProportions.GreenMedical), projectedSubGlass.ProjectedHouseholdDrinksContainerRAMTonnage!.GreenMedicalTonnage);
+        }
+
+        [TestMethod]
         public void ReconcileRoundingDifference_NoMissingRam()
         {
             var tonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 0, AmberTonnage = 20, GreenTonnage = 30, RedMedicalTonnage = 0, AmberMedicalTonnage = 50, GreenMedicalTonnage = 0 };
@@ -430,6 +507,68 @@
             Assert.AreEqual(withProportions with { AmberTonnage = withProportions.AmberTonnage + roundingDiff }, reconciled);
         }
 
+        [TestMethod]
+        public void SumProducerGroupTonnages_CorrectlyTotalsProportionForHC()
+        {
+            var expRamH2Proportions = new RAMProportions { Red = 50, Amber = 50, Green = 0, RedMedical = 0, AmberMedical = 0, GreenMedical = 0 };
+            var prodGroup = new List<CalcResultH1ProjectedProducer>() 
+            {
+                new (){
+                    ProducerId = 11,
+                    SubsidiaryId = null,
+                    SubmissionPeriodCode = "2025-H1",
+                    Level = string.Empty,
+                    H1ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH1ProjectedProducerMaterialTonnage>() {
+                        ["AL"] = new() {
+                            HouseholdRAMTonnage = new RAMTonnage { Tonnage = 100, RedTonnage = 100, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            PublicBinRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 0, AmberTonnage = 100, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            HouseholdTonnageWithoutRAM = 0,
+                            PublicBinTonnageWithoutRAM = 100,
+                            H2RamProportions = expRamH2Proportions,
+                            TotalTonnage = 300,
+                            ProjectedHouseholdRAMTonnage = new RAMTonnage { Tonnage = 100, RedTonnage = 100, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            ProjectedPublicBinRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 50, AmberTonnage = 150, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 }
+                        }
+                    }
+                },
+                new (){
+                    ProducerId = 11,
+                    SubsidiaryId = "A",
+                    SubmissionPeriodCode = "2025-H1",
+                    Level = string.Empty,
+                    H1ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH1ProjectedProducerMaterialTonnage>() {
+                        ["AL"] = new() {
+                            HouseholdRAMTonnage = new RAMTonnage { Tonnage = 100, RedTonnage = 100, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            PublicBinRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 0, AmberTonnage = 100, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            HouseholdTonnageWithoutRAM = 0,
+                            PublicBinTonnageWithoutRAM = 100,
+                            H2RamProportions = expRamH2Proportions,
+                            TotalTonnage = 300,
+                            ProjectedHouseholdRAMTonnage = new RAMTonnage { Tonnage = 100, RedTonnage = 100, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            ProjectedPublicBinRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 50, AmberTonnage = 150, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 }
+                        }
+                    }
+                },
+            };
+            
+            var expSummedAlm = new CalcResultH1ProjectedProducerMaterialTonnage() {
+                HouseholdRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 200, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                PublicBinRAMTonnage = new RAMTonnage { Tonnage = 400, RedTonnage = 0, AmberTonnage = 200, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                HouseholdTonnageWithoutRAM = 0,
+                PublicBinTonnageWithoutRAM = 200,
+                H2RamProportions = expRamH2Proportions,
+                TotalTonnage = 600,
+                ProjectedHouseholdRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 200, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                ProjectedPublicBinRAMTonnage = new RAMTonnage { Tonnage = 400, RedTonnage = 100, AmberTonnage = 300, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 }
+            };
+
+            var result = H1ProjectedProducersBuilderUtils.SumProducerGroupTonnages(prodGroup);
+
+            Assert.IsTrue(result.IsSubtotal);
+            Assert.AreEqual("1", result.Level);
+            Assert.AreEqual(expSummedAlm, result.H1ProjectedTonnageByMaterial["AL"]);
+        }
+
         private decimal To3DP(decimal value)
         {
             return Math.Round(value, 3);
@@ -479,6 +618,30 @@
             });
         }
 
+        private (ProducerReportedMaterial, ProducerReportedMaterial, ProducerReportedMaterial, ProducerReportedMaterial, List<ProducerReportedMaterialsForSubmissionPeriod>) GetH1NoRamReportedMaterialsWithSubsidiary()
+        {
+            var hhAlm = new ProducerReportedMaterial { MaterialId = 1, PackagingType = PackagingTypes.Household, PackagingTonnage = 100, SubmissionPeriod = "2026-H1" };
+            var hhSubAlm = new ProducerReportedMaterial { MaterialId = 1, PackagingType = PackagingTypes.Household, PackagingTonnage = 200, SubmissionPeriod = "2026-H1" };
+            var hdcGlass = new ProducerReportedMaterial { MaterialId = 2, PackagingType = PackagingTypes.HouseholdDrinksContainers, PackagingTonnage = 200, SubmissionPeriod = "2026-H1" };
+            var hdcSubGlass = new ProducerReportedMaterial { MaterialId = 2, PackagingType = PackagingTypes.HouseholdDrinksContainers, PackagingTonnage = 50, SubmissionPeriod = "2026-H1" };
+            return (hhAlm, hdcGlass, hhSubAlm, hdcSubGlass, new List<ProducerReportedMaterialsForSubmissionPeriod>()
+            {
+                new(
+                    producerId: 11,
+                    subsidiaryId: null,
+                    submissionPeriod: "2026-H1",
+                    new List<ProducerReportedMaterial>{ hhAlm, hdcGlass }
+                ),
+                new(
+                    producerId: 11,
+                    subsidiaryId: "A",
+                    submissionPeriod: "2026-H1",
+                    new List<ProducerReportedMaterial>{ hhSubAlm, hdcSubGlass }
+                )
+            });
+        }
+
+
         private (ProducerReportedMaterial, ProducerReportedMaterial, List<ProducerReportedMaterialsForSubmissionPeriod>) GetH1PartialRamReportedMaterials()
         {
             var hhAlm = new ProducerReportedMaterial { MaterialId = 1, PackagingType = PackagingTypes.Household, PackagingTonnage = 100, PackagingTonnageRed = 0, PackagingTonnageAmber = 50, PackagingTonnageGreen = 0, PackagingTonnageRedMedical = 0, PackagingTonnageAmberMedical = 25, PackagingTonnageGreenMedical = 0, SubmissionPeriod = "2026-H1" };
@@ -506,6 +669,73 @@
                     submissionPeriod: "2026-H1",
                     new List<ProducerReportedMaterial>{ hhAlm, hdcGlass }
                 )
+            });
+        }
+
+        private (CalcResultH2ProjectedProducerMaterialTonnage, CalcResultH2ProjectedProducerMaterialTonnage, List<CalcResultH2ProjectedProducer>) GetH2WithHCSubtotal()
+        {
+            var alm = new CalcResultH2ProjectedProducerMaterialTonnage 
+                        { 
+                            HouseholdRAMTonnage = new RAMTonnage { Tonnage = 75, RedTonnage = 10, AmberTonnage = 11, GreenTonnage = 12, RedMedicalTonnage = 13, AmberMedicalTonnage = 14, GreenMedicalTonnage = 15 },
+                            PublicBinRAMTonnage = new RAMTonnage { Tonnage = 135, RedTonnage = 20, AmberTonnage = 21, GreenTonnage = 22, RedMedicalTonnage = 23, AmberMedicalTonnage = 24, GreenMedicalTonnage = 25 },
+                            HouseholdTonnageWithoutRAM = 0,
+                            PublicBinTonnageWithoutRAM = 0,
+                            TotalTonnage = 210,
+                            ProjectedHouseholdRAMTonnage = new RAMTonnage { Tonnage = 75, RedTonnage = 10, AmberTonnage = 11, GreenTonnage = 12, RedMedicalTonnage = 13, AmberMedicalTonnage = 14, GreenMedicalTonnage = 15 },
+                            ProjectedPublicBinRAMTonnage = new RAMTonnage { Tonnage = 135, RedTonnage = 20, AmberTonnage = 21, GreenTonnage = 22, RedMedicalTonnage = 23, AmberMedicalTonnage = 24, GreenMedicalTonnage = 25 },
+                        };
+            var glass = new CalcResultH2ProjectedProducerMaterialTonnage 
+                        { 
+                            HouseholdRAMTonnage = new RAMTonnage { Tonnage = 75, RedTonnage = 10, AmberTonnage = 11, GreenTonnage = 12, RedMedicalTonnage = 13, AmberMedicalTonnage = 14, GreenMedicalTonnage = 15 },
+                            PublicBinRAMTonnage = new RAMTonnage { Tonnage = 135, RedTonnage = 20, AmberTonnage = 21, GreenTonnage = 22, RedMedicalTonnage = 23, AmberMedicalTonnage = 24, GreenMedicalTonnage = 25 },
+                            HouseholdDrinksContainerRAMTonnage = new RAMTonnage { Tonnage = 195, RedTonnage = 30, AmberTonnage = 31, GreenTonnage = 32, RedMedicalTonnage = 33, AmberMedicalTonnage = 34, GreenMedicalTonnage = 35 },
+                            HouseholdTonnageWithoutRAM = 0,
+                            PublicBinTonnageWithoutRAM = 0,
+                            HouseholdDrinksContainerTonnageWithoutRAM = 0,
+                            TotalTonnage = 405,
+                            ProjectedHouseholdRAMTonnage = new RAMTonnage { Tonnage = 75, RedTonnage = 10, AmberTonnage = 11, GreenTonnage = 12, RedMedicalTonnage = 13, AmberMedicalTonnage = 14, GreenMedicalTonnage = 15 },
+                            ProjectedPublicBinRAMTonnage = new RAMTonnage { Tonnage = 135, RedTonnage = 20, AmberTonnage = 21, GreenTonnage = 22, RedMedicalTonnage = 23, AmberMedicalTonnage = 24, GreenMedicalTonnage = 25 },
+                            ProjectedHouseholdDrinksContainerRAMTonnage = new RAMTonnage { Tonnage = 195, RedTonnage = 30, AmberTonnage = 31, GreenTonnage = 32, RedMedicalTonnage = 33, AmberMedicalTonnage = 34, GreenMedicalTonnage = 35 },
+                        };
+            return (alm, glass, new List<CalcResultH2ProjectedProducer>()
+            {
+                new()
+                {
+                    ProducerId = 11,
+                    SubsidiaryId = null,
+                    Level = string.Empty,
+                    SubmissionPeriodCode = "2026-H2",
+                    IsSubtotal = true,
+                    H2ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH2ProjectedProducerMaterialTonnage>
+                    {
+                        { MaterialCodes.Aluminium, alm },
+                        { MaterialCodes.Glass, glass }
+                    } 
+                },
+                new()
+                {
+                    ProducerId = 11,
+                    SubsidiaryId = null,
+                    Level = string.Empty,
+                    SubmissionPeriodCode = "2026-H2",
+                    H2ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH2ProjectedProducerMaterialTonnage>
+                    {
+                        { MaterialCodes.Aluminium, GetEmptyH2MaterialTonnage() },
+                        { MaterialCodes.Glass, GetEmptyH2MaterialTonnageWithHDC() }
+                    } 
+                },
+                new()
+                {
+                    ProducerId = 11,
+                    SubsidiaryId = "A",
+                    Level = string.Empty,
+                    SubmissionPeriodCode = "2026-H2",
+                    H2ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH2ProjectedProducerMaterialTonnage>
+                    {
+                        { MaterialCodes.Aluminium, GetEmptyH2MaterialTonnage() },
+                        { MaterialCodes.Glass, GetEmptyH2MaterialTonnageWithHDC() }
+                    } 
+                }
             });
         }
 
@@ -594,30 +824,40 @@
             });
         }
 
+        private CalcResultH2ProjectedProducerMaterialTonnage GetEmptyH2MaterialTonnage()
+        {
+            return new CalcResultH2ProjectedProducerMaterialTonnage 
+            { 
+                HouseholdRAMTonnage = EmptyRAMTonnage(),
+                PublicBinRAMTonnage = EmptyRAMTonnage(),
+                HouseholdTonnageWithoutRAM = 0,
+                PublicBinTonnageWithoutRAM = 0,
+                TotalTonnage = 0,
+                ProjectedHouseholdRAMTonnage = EmptyRAMTonnage(),
+                ProjectedPublicBinRAMTonnage = EmptyRAMTonnage(),
+            };
+        }
+
+        private CalcResultH2ProjectedProducerMaterialTonnage GetEmptyH2MaterialTonnageWithHDC()
+        {
+            return new CalcResultH2ProjectedProducerMaterialTonnage 
+            { 
+                HouseholdRAMTonnage = EmptyRAMTonnage(),
+                PublicBinRAMTonnage = EmptyRAMTonnage(),
+                HouseholdDrinksContainerRAMTonnage = EmptyRAMTonnage(),
+                HouseholdTonnageWithoutRAM = 0,
+                PublicBinTonnageWithoutRAM = 0,
+                TotalTonnage = 0,
+                ProjectedHouseholdRAMTonnage = EmptyRAMTonnage(),
+                ProjectedPublicBinRAMTonnage = EmptyRAMTonnage(),
+                ProjectedHouseholdDrinksContainerRAMTonnage = EmptyRAMTonnage(),
+            };
+}
+
         private (CalcResultH2ProjectedProducerMaterialTonnage, CalcResultH2ProjectedProducerMaterialTonnage, List<CalcResultH2ProjectedProducer>) GetH2NoReportedMaterialProjectedProducers()
         {
-            var alm = new CalcResultH2ProjectedProducerMaterialTonnage 
-                        { 
-                            HouseholdRAMTonnage = EmptyRAMTonnage(),
-                            PublicBinRAMTonnage = EmptyRAMTonnage(),
-                            HouseholdTonnageWithoutRAM = 0,
-                            PublicBinTonnageWithoutRAM = 0,
-                            TotalTonnage = 0,
-                            ProjectedHouseholdRAMTonnage = EmptyRAMTonnage(),
-                            ProjectedPublicBinRAMTonnage = EmptyRAMTonnage(),
-                        };
-            var glass = new CalcResultH2ProjectedProducerMaterialTonnage 
-                        { 
-                            HouseholdRAMTonnage = EmptyRAMTonnage(),
-                            PublicBinRAMTonnage = EmptyRAMTonnage(),
-                            HouseholdDrinksContainerRAMTonnage = EmptyRAMTonnage(),
-                            HouseholdTonnageWithoutRAM = 0,
-                            PublicBinTonnageWithoutRAM = 0,
-                            TotalTonnage = 0,
-                            ProjectedHouseholdRAMTonnage = EmptyRAMTonnage(),
-                            ProjectedPublicBinRAMTonnage = EmptyRAMTonnage(),
-                            ProjectedHouseholdDrinksContainerRAMTonnage = EmptyRAMTonnage(),
-                        };
+            var alm = GetEmptyH2MaterialTonnage();
+            var glass = GetEmptyH2MaterialTonnageWithHDC();
             return (alm, glass, new List<CalcResultH2ProjectedProducer>()
             {
                 new()

--- a/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/H2ProjectedProducersBuilderUtilsTest.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Builder/ProjectedProducers/H2ProjectedProducersBuilderUtilsTest.cs
@@ -106,5 +106,63 @@
             Assert.AreEqual(expProd11Sub22HDCTotalTonnage, prod11Sub22Glass.TotalTonnage);
             Assert.AreEqual(expProd11Sub22HDC with { RedTonnage = 500 }, prod11Sub22Glass.ProjectedHouseholdDrinksContainerRAMTonnage);
         }
+
+        [TestMethod]
+        public void SumProducerGroupTonnages_CorrectlySums()
+        {
+            var prodGroup = new List<CalcResultH2ProjectedProducer>() 
+            {
+                new (){
+                    ProducerId = 11,
+                    SubsidiaryId = null,
+                    SubmissionPeriodCode = "2025-H1",
+                    Level = string.Empty,
+                    H2ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH2ProjectedProducerMaterialTonnage>() {
+                        ["AL"] = new() {
+                            HouseholdRAMTonnage = new RAMTonnage { Tonnage = 100, RedTonnage = 100, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            PublicBinRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 0, AmberTonnage = 100, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            HouseholdTonnageWithoutRAM = 0,
+                            PublicBinTonnageWithoutRAM = 100,
+                            TotalTonnage = 300,
+                            ProjectedHouseholdRAMTonnage = new RAMTonnage { Tonnage = 100, RedTonnage = 100, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            ProjectedPublicBinRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 100, AmberTonnage = 100, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 }
+                        }
+                    }
+                },
+                new (){
+                    ProducerId = 11,
+                    SubsidiaryId = "A",
+                    SubmissionPeriodCode = "2025-H1",
+                    Level = string.Empty,
+                    H2ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH2ProjectedProducerMaterialTonnage>() {
+                        ["AL"] = new() {
+                            HouseholdRAMTonnage = new RAMTonnage { Tonnage = 100, RedTonnage = 100, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            PublicBinRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 0, AmberTonnage = 100, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            HouseholdTonnageWithoutRAM = 0,
+                            PublicBinTonnageWithoutRAM = 100,
+                            TotalTonnage = 300,
+                            ProjectedHouseholdRAMTonnage = new RAMTonnage { Tonnage = 100, RedTonnage = 100, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                            ProjectedPublicBinRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 100, AmberTonnage = 100, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 }
+                        }
+                    }
+                },
+            };
+            
+            var expSummedAlm = new CalcResultH2ProjectedProducerMaterialTonnage() {
+                HouseholdRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 200, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                PublicBinRAMTonnage = new RAMTonnage { Tonnage = 400, RedTonnage = 0, AmberTonnage = 200, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                HouseholdTonnageWithoutRAM = 0,
+                PublicBinTonnageWithoutRAM = 200,
+                TotalTonnage = 600,
+                ProjectedHouseholdRAMTonnage = new RAMTonnage { Tonnage = 200, RedTonnage = 200, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
+                ProjectedPublicBinRAMTonnage = new RAMTonnage { Tonnage = 400, RedTonnage = 200, AmberTonnage = 200, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 }
+            };
+
+            var result = H2ProjectedProducersBuilderUtils.SumProducerGroupTonnages(prodGroup);
+
+            Assert.IsTrue(result.IsSubtotal);
+            Assert.AreEqual("1", result.Level);
+            Assert.AreEqual(expSummedAlm, result.H2ProjectedTonnageByMaterial["AL"]);
+        }
     }
 }

--- a/src/EPR.Calculator.Service.Function.UnitTests/Exporter/CsvExporter/ProjectedProducers/CalcResultProjectedProducersExporterTests.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Exporter/CsvExporter/ProjectedProducers/CalcResultProjectedProducersExporterTests.cs
@@ -162,6 +162,53 @@ namespace EPR.Calculator.Service.Function.UnitTests.Exporter.CsvExporter.Project
         }
 
         [TestMethod]
+        public void Export_ShouldIncludeProjectedProducers_WhichWereNotComplete()
+        {
+            var completeProjectedProducers = new CalcResultProjectedProducers
+            {
+                H2ProjectedProducersHeaders = H2ProjectedProducersBuilderUtils.GetProjectedProducerHeaders(materials),
+                H2ProjectedProducers = GetH2ProjectedProducersList().Concat(GetCompleteH2ProjectedProducersList()),
+                H1ProjectedProducersHeaders = H1ProjectedProducersBuilderUtils.GetProjectedProducerHeaders(materials),
+                H1ProjectedProducers = GetH1ProjectedProducersList().Concat(GetCompleteH1ProjectedProducersList()),
+            };
+
+            var csvContent = new StringBuilder();
+
+            exporter.Export(completeProjectedProducers, csvContent);
+
+            Assert.IsTrue(csvContent.ToString().Contains("101001"));
+            Assert.IsFalse(csvContent.ToString().Contains("202002"));
+            Assert.IsFalse(csvContent.ToString().Contains("ABC"));
+            Assert.IsFalse(csvContent.ToString().Contains("CDE"));
+        }
+
+        [TestMethod]
+        public void Export_ShouldIncludeEmptyProjectedProducers_WhenAllAreH2H1Complete()
+        {
+            var completeProjectedProducers = new CalcResultProjectedProducers
+            {
+                H2ProjectedProducersHeaders = H2ProjectedProducersBuilderUtils.GetProjectedProducerHeaders(materials),
+                H2ProjectedProducers = GetCompleteH2ProjectedProducersList(),
+                H1ProjectedProducersHeaders = H1ProjectedProducersBuilderUtils.GetProjectedProducerHeaders(materials),
+                H1ProjectedProducers = GetCompleteH1ProjectedProducersList(),
+            };
+
+            var csvContent = new StringBuilder();
+
+            exporter.Export(completeProjectedProducers, csvContent);
+
+            var rows = csvContent.ToString()
+                        .Split(Environment.NewLine)
+                        .Select(r => r.Split(','))
+                        .ToArray();
+
+            Assert.IsTrue(rows[2][0].Contains(CalcResultProjectedProducersHeaders.H2ProjectedProducers));
+            Assert.IsTrue(rows[6][0].Contains(CalcResultProjectedProducersHeaders.NoProjectedProducers));
+            Assert.IsTrue(rows[9][0].Contains(CalcResultProjectedProducersHeaders.H1ProjectedProducers));
+            Assert.IsTrue(rows[13][0].Contains(CalcResultProjectedProducersHeaders.NoProjectedProducers));
+        }
+
+        [TestMethod]
         public void Export_ShouldIncludeEmptyProjectedProducers_WhenNull()
         {
             var projectedProducers = new CalcResultProjectedProducers
@@ -233,6 +280,114 @@ namespace EPR.Calculator.Service.Function.UnitTests.Exporter.CsvExporter.Project
                 };
         }
 
+        private List<CalcResultH2ProjectedProducer> GetCompleteH2ProjectedProducersList()
+        {
+            return new List<CalcResultH2ProjectedProducer>()
+                {
+                    new CalcResultH2ProjectedProducer
+                    {
+                        ProducerId = 202002,
+                        SubsidiaryId = null,
+                        Level = "1",
+                        SubmissionPeriodCode = "2026-H2",
+                        H2ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH2ProjectedProducerMaterialTonnage>
+                        {
+                            {
+                                "AL",
+                                new CalcResultH2ProjectedProducerMaterialTonnage
+                                {
+                                   HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 60, RedMedicalTonnage = 80, AmberTonnage = 80, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   HouseholdTonnageWithoutRAM = 0,
+                                   PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 400, RedTonnage = 100, RedMedicalTonnage = 40, AmberTonnage = 60, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   PublicBinTonnageWithoutRAM = 0,
+                                   TotalTonnage = 600,
+                                   ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 60, RedMedicalTonnage = 80, AmberTonnage = 80, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 400, RedTonnage = 100, RedMedicalTonnage = 40, AmberTonnage = 60, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                }
+                            },
+                            {
+                                "GL",
+                                new CalcResultH2ProjectedProducerMaterialTonnage
+                                {
+                                    HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdTonnageWithoutRAM = 0,
+                                    PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    PublicBinTonnageWithoutRAM = 0,
+                                    HouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 500, RedTonnage = 500, RedMedicalTonnage = 0, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdDrinksContainerTonnageWithoutRAM = 0,
+                                    TotalTonnage = 800,
+                                    ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedHouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 500, RedTonnage = 500, RedMedicalTonnage = 0, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                }
+                            },
+                        },
+                    },
+                    new CalcResultH2ProjectedProducer
+                    {
+                        ProducerId = 202002,
+                        SubsidiaryId = null,
+                        Level = "2",
+                        SubmissionPeriodCode = "2026-H2",
+                        H2ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH2ProjectedProducerMaterialTonnage>
+                        {
+                            {
+                                "AL",
+                                new CalcResultH2ProjectedProducerMaterialTonnage
+                                {
+                                   HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   HouseholdTonnageWithoutRAM = 0,
+                                   PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   PublicBinTonnageWithoutRAM = 0,
+                                   TotalTonnage = 300,
+                                   ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                }
+                            },
+                            {
+                                "GL",
+                                new CalcResultH2ProjectedProducerMaterialTonnage
+                                {
+                                    HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdTonnageWithoutRAM = 0,
+                                    PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    PublicBinTonnageWithoutRAM = 0,
+                                    HouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 500, RedTonnage = 500, RedMedicalTonnage = 0, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdDrinksContainerTonnageWithoutRAM = 0,
+                                    TotalTonnage = 800,
+                                    ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedHouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 500, RedTonnage = 500, RedMedicalTonnage = 0, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                }
+                            },
+                        },
+                    },
+                    new CalcResultH2ProjectedProducer
+                    {
+                        ProducerId = 202002,
+                        SubsidiaryId = "ABC",
+                        Level = "2",
+                        SubmissionPeriodCode = "2026-H2",
+                        H2ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH2ProjectedProducerMaterialTonnage>
+                        {
+                            {
+                                "AL",
+                                new CalcResultH2ProjectedProducerMaterialTonnage
+                                {
+                                   HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   HouseholdTonnageWithoutRAM = 0,
+                                   PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   PublicBinTonnageWithoutRAM = 0,
+                                   TotalTonnage = 300,
+                                   ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                }
+                            }
+                        },
+                    }
+                };
+        }
+
         private List<CalcResultH1ProjectedProducer> GetH1ProjectedProducersList()
         {
             return new List<CalcResultH1ProjectedProducer>()
@@ -290,6 +445,122 @@ namespace EPR.Calculator.Service.Function.UnitTests.Exporter.CsvExporter.Project
                                     TotalTonnage = 300
                                 }
                             },
+                        },
+                    },
+                };
+        }
+
+        private List<CalcResultH1ProjectedProducer> GetCompleteH1ProjectedProducersList()
+        {
+            return new List<CalcResultH1ProjectedProducer>()
+                {
+                    new CalcResultH1ProjectedProducer
+                    {
+                        ProducerId = 202002,
+                        SubsidiaryId = null,
+                        Level = "1",
+                        SubmissionPeriodCode = "2026-H1",
+                        H1ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH1ProjectedProducerMaterialTonnage>
+                        {
+                            {
+                                "AL",
+                                new CalcResultH1ProjectedProducerMaterialTonnage
+                                {
+                                   HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   HouseholdTonnageWithoutRAM = 0,
+                                   PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   PublicBinTonnageWithoutRAM = 0,
+                                   H2RamProportions = new RAMProportions { Red = 0.1m, Amber = 0.2m, Green = 0.3m, RedMedical = 0.4m, AmberMedical = 0.5m, GreenMedical = 0.6m },
+                                   ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   TotalTonnage = 300
+                                }
+                            },
+                            {
+                                "GL",
+                                new CalcResultH1ProjectedProducerMaterialTonnage
+                                {
+                                    HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 60, RedMedicalTonnage = 80, AmberTonnage = 80, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdTonnageWithoutRAM = 0,
+                                    PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 400, RedTonnage = 100, RedMedicalTonnage = 40, AmberTonnage = 60, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    PublicBinTonnageWithoutRAM = 0,
+                                    HouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 1000, RedTonnage = 800, RedMedicalTonnage = 200, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdDrinksContainerTonnageWithoutRAM = 0,
+                                    H2RamProportions = new RAMProportions { Red = 0.6m, Amber = 0.5m, Green = 0.4m, RedMedical = 0.3m, AmberMedical = 0.2m, GreenMedical = 0.1m },
+                                    ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 60, RedMedicalTonnage = 80, AmberTonnage = 80, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 400, RedTonnage = 100, RedMedicalTonnage = 40, AmberTonnage = 60, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedHouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 1000, RedTonnage = 800, RedMedicalTonnage = 200, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    TotalTonnage = 800
+                                }
+                            }
+                        },
+                    },
+                    new CalcResultH1ProjectedProducer
+                    {
+                        ProducerId = 202002,
+                        SubsidiaryId = null,
+                        Level = "2",
+                        SubmissionPeriodCode = "2026-H1",
+                        H1ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH1ProjectedProducerMaterialTonnage>
+                        {
+                            {
+                                "GL",
+                                new CalcResultH1ProjectedProducerMaterialTonnage
+                                {
+                                    HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdTonnageWithoutRAM = 0,
+                                    PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    PublicBinTonnageWithoutRAM = 0,
+                                    HouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 500, RedTonnage = 400, RedMedicalTonnage = 100, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdDrinksContainerTonnageWithoutRAM = 0,
+                                    H2RamProportions = new RAMProportions { Red = 0.6m, Amber = 0.5m, Green = 0.4m, RedMedical = 0.3m, AmberMedical = 0.2m, GreenMedical = 0.1m },
+                                    ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedHouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 500, RedTonnage = 400, RedMedicalTonnage = 100, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    TotalTonnage = 800
+                                }
+                            }
+                        },
+                    },
+                    new CalcResultH1ProjectedProducer
+                    {
+                        ProducerId = 202002,
+                        SubsidiaryId = "CDE",
+                        Level = "2",
+                        SubmissionPeriodCode = "2026-H1",
+                        H1ProjectedTonnageByMaterial = new Dictionary<string, CalcResultH1ProjectedProducerMaterialTonnage>
+                        {
+                            {
+                                "AL",
+                                new CalcResultH1ProjectedProducerMaterialTonnage
+                                {
+                                   HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   HouseholdTonnageWithoutRAM = 0,
+                                   PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   PublicBinTonnageWithoutRAM = 0,
+                                   H2RamProportions = new RAMProportions { Red = 0.1m, Amber = 0.2m, Green = 0.3m, RedMedical = 0.4m, AmberMedical = 0.5m, GreenMedical = 0.6m },
+                                   ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                   TotalTonnage = 300
+                                }
+                            },
+                            {
+                                "GL",
+                                new CalcResultH1ProjectedProducerMaterialTonnage
+                                {
+                                    HouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdTonnageWithoutRAM = 0,
+                                    PublicBinRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    PublicBinTonnageWithoutRAM = 0,
+                                    HouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 500, RedTonnage = 400, RedMedicalTonnage = 100, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    HouseholdDrinksContainerTonnageWithoutRAM = 0,
+                                    H2RamProportions = new RAMProportions { Red = 0.6m, Amber = 0.5m, Green = 0.4m, RedMedical = 0.3m, AmberMedical = 0.2m, GreenMedical = 0.1m },
+                                    ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 30, RedMedicalTonnage = 40, AmberTonnage = 40, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 200, RedTonnage = 50, RedMedicalTonnage = 20, AmberTonnage = 30, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    ProjectedHouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 500, RedTonnage = 400, RedMedicalTonnage = 100, AmberTonnage = 0, AmberMedicalTonnage = 0, GreenTonnage = 0, GreenMedicalTonnage = 0 },
+                                    TotalTonnage = 800
+                                }
+                            }
                         },
                     },
                 };

--- a/src/EPR.Calculator.Service.Function.UnitTests/Exporter/CsvExporter/ProjectedProducers/CalcResultProjectedProducersExporterTests.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Exporter/CsvExporter/ProjectedProducers/CalcResultProjectedProducersExporterTests.cs
@@ -256,8 +256,7 @@ namespace EPR.Calculator.Service.Function.UnitTests.Exporter.CsvExporter.Project
                                    H2RamProportions = new RAMProportions { Red = 0.1m, Amber = 0.2m, Green = 0.3m, RedMedical = 0.4m, AmberMedical = 0.5m, GreenMedical = 0.6m },
                                    ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 50, RedTonnage = 15, RedMedicalTonnage = 20, AmberTonnage = 10, AmberMedicalTonnage = 0, GreenTonnage = 20, GreenMedicalTonnage = 0 },
                                    ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 25, RedMedicalTonnage = 10, AmberTonnage = 20, AmberMedicalTonnage = 0, GreenTonnage = 50, GreenMedicalTonnage = 0 },
-                                   TotalTonnage = 300,
-                                   H2TotalTonnage = 300
+                                   TotalTonnage = 300
                                 }
                             },
                             {
@@ -274,8 +273,7 @@ namespace EPR.Calculator.Service.Function.UnitTests.Exporter.CsvExporter.Project
                                     ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 15, RedMedicalTonnage = 20, AmberTonnage = 10, AmberMedicalTonnage = 0, GreenTonnage = 20, GreenMedicalTonnage = 0 },
                                     ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 50, RedTonnage = 25, RedMedicalTonnage = 10, AmberTonnage = 20, AmberMedicalTonnage = 0, GreenTonnage = 50, GreenMedicalTonnage = 0 },
                                     ProjectedHouseholdDrinksContainerRAMTonnage = new RAMTonnage{ Tonnage = 700, RedTonnage = 50, RedMedicalTonnage = 200, AmberTonnage = 200, AmberMedicalTonnage = 0, GreenTonnage = 50, GreenMedicalTonnage = 0 },
-                                    TotalTonnage = 300,
-                                    H2TotalTonnage = 700
+                                    TotalTonnage = 300
                                 }
                             },
                             {
@@ -289,8 +287,7 @@ namespace EPR.Calculator.Service.Function.UnitTests.Exporter.CsvExporter.Project
                                     H2RamProportions = new RAMProportions { Red = 0, Amber = 0, Green = 0, RedMedical = 0, AmberMedical = 0, GreenMedical = 0 },
                                     ProjectedHouseholdRAMTonnage = new RAMTonnage{ Tonnage = 100, RedTonnage = 15, RedMedicalTonnage = 20, AmberTonnage = 10, AmberMedicalTonnage = 0, GreenTonnage = 20, GreenMedicalTonnage = 0 },
                                     ProjectedPublicBinRAMTonnage = new RAMTonnage{ Tonnage = 50, RedTonnage = 25, RedMedicalTonnage = 10, AmberTonnage = 20, AmberMedicalTonnage = 0, GreenTonnage = 50, GreenMedicalTonnage = 0 },
-                                    TotalTonnage = 300,
-                                    H2TotalTonnage = 0
+                                    TotalTonnage = 300
                                 }
                             },
                         },

--- a/src/EPR.Calculator.Service.Function.UnitTests/Services/ProjectedProducersServiceTest.cs
+++ b/src/EPR.Calculator.Service.Function.UnitTests/Services/ProjectedProducersServiceTest.cs
@@ -152,7 +152,6 @@ namespace EPR.Calculator.Service.Function.UnitTests.Services
                                 PublicBinTonnageWithoutRAM = 0,
                                 TotalTonnage = 100,
                                 H2RamProportions = new RAMProportions { Red = 0.2m, Amber = 0.2m, Green = 0.2m, RedMedical = 0.2m, AmberMedical = 0.2m, GreenMedical = 0 },
-                                H2TotalTonnage = 100,
                                 ProjectedHouseholdRAMTonnage = new RAMTonnage() { Tonnage = 100, RedTonnage = 20, AmberTonnage = 20, GreenTonnage = 20, RedMedicalTonnage = 20, AmberMedicalTonnage = 20, GreenMedicalTonnage = 0 },
                                 ProjectedPublicBinRAMTonnage = new RAMTonnage() { Tonnage = 0, RedTonnage = 0, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 }
                             },
@@ -164,7 +163,6 @@ namespace EPR.Calculator.Service.Function.UnitTests.Services
                                 PublicBinTonnageWithoutRAM = 50,
                                 TotalTonnage = 50,
                                 H2RamProportions = new RAMProportions { Red = 1, Amber = 0, Green = 0, RedMedical = 0, AmberMedical = 0, GreenMedical = 0 },
-                                H2TotalTonnage = 100,
                                 ProjectedHouseholdRAMTonnage = new RAMTonnage() { Tonnage = 0, RedTonnage = 0, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
                                 ProjectedPublicBinRAMTonnage = new RAMTonnage() { Tonnage = 50, RedTonnage = 50, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },   
                             }
@@ -188,7 +186,6 @@ namespace EPR.Calculator.Service.Function.UnitTests.Services
                                 HouseholdDrinksContainerTonnageWithoutRAM = 100,
                                 TotalTonnage = 250,
                                 H2RamProportions = new RAMProportions { Red = 0, Amber = 0, Green = 0, RedMedical = 0.5m, AmberMedical = 0, GreenMedical = 0.5m },
-                                H2TotalTonnage = 100,
                                 ProjectedHouseholdRAMTonnage = new RAMTonnage() { Tonnage = 50, RedTonnage = 20, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 10, AmberMedicalTonnage = 0, GreenMedicalTonnage = 10 },
                                 ProjectedPublicBinRAMTonnage = new RAMTonnage() { Tonnage = 0, RedTonnage = 0, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
                                 ProjectedHouseholdDrinksContainerRAMTonnage = new RAMTonnage() { Tonnage = 200, RedTonnage = 0, AmberTonnage = 100, GreenTonnage = 0, RedMedicalTonnage = 50, AmberMedicalTonnage = 0, GreenMedicalTonnage = 50 }
@@ -212,7 +209,6 @@ namespace EPR.Calculator.Service.Function.UnitTests.Services
                                 HouseholdDrinksContainerTonnageWithoutRAM = 100,
                                 TotalTonnage = 250,
                                 H2RamProportions = new RAMProportions { Red = 0, Amber = 0, Green = 0, RedMedical = 0.5m, AmberMedical = 0, GreenMedical = 0.5m },
-                                H2TotalTonnage = 100,
                                 ProjectedHouseholdRAMTonnage = new RAMTonnage() { Tonnage = 0, RedTonnage = 0, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
                                 ProjectedPublicBinRAMTonnage = new RAMTonnage() { Tonnage = 50, RedTonnage = 20, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 10, AmberMedicalTonnage = 0, GreenMedicalTonnage = 10 },
                                 ProjectedHouseholdDrinksContainerRAMTonnage = new RAMTonnage() { Tonnage = 200, RedTonnage = 0, AmberTonnage = 100, GreenTonnage = 0, RedMedicalTonnage = 50, AmberMedicalTonnage = 0, GreenMedicalTonnage = 50 }

--- a/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/CalcResultProjectedProducersBuilder.cs
+++ b/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/CalcResultProjectedProducersBuilder.cs
@@ -52,13 +52,24 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
                 createSubtotal: H1ProjectedProducersBuilderUtils.CreateParentProducer,
                 sumProducerGroupTonnages: H1ProjectedProducersBuilderUtils.SumProducerGroupTonnages
             );
+            
+            var completeH1AndH2RamProducers = h2ProjectedProducersWithSubtotals
+                .Cast<ICalcResultProjectedProducer>()
+                .Concat(h1ProjectedProducersWithSubtotals)
+                .GroupBy(p => p.ProducerId)
+                .Where(g => g.All(p => p.ProjectedTonnageByMaterial.All(m => !m.Value.IsWithoutRamTonnage())))
+                .Select(g => g.Key)
+                .ToHashSet();
+
+            var h2ProjectedProducersFiltered = h2ProjectedProducersWithSubtotals.Where(p => !completeH1AndH2RamProducers.Contains(p.ProducerId));
+            var h1ProjectedProducersFiltered = h1ProjectedProducersWithSubtotals.Where(p => !completeH1AndH2RamProducers.Contains(p.ProducerId));
 
             return new CalcResultProjectedProducers
             {
                 H2ProjectedProducersHeaders = H2ProjectedProducersBuilderUtils.GetProjectedProducerHeaders(materials),
                 H1ProjectedProducersHeaders = H1ProjectedProducersBuilderUtils.GetProjectedProducerHeaders(materials),
-                H2ProjectedProducers = h2ProjectedProducersWithSubtotals.OrderBy(p => p.ProducerId).ThenBy(p => p.Level).ThenBy(p => p.SubsidiaryId).ToList(),
-                H1ProjectedProducers = h1ProjectedProducersWithSubtotals.OrderBy(p => p.ProducerId).ThenBy(p => p.Level).ThenBy(p => p.SubsidiaryId).ToList()
+                H2ProjectedProducers = h2ProjectedProducersFiltered.OrderBy(p => p.ProducerId).ThenBy(p => p.Level).ThenBy(p => p.SubsidiaryId).ToList(),
+                H1ProjectedProducers = h1ProjectedProducersFiltered.OrderBy(p => p.ProducerId).ThenBy(p => p.Level).ThenBy(p => p.SubsidiaryId).ToList()
             };
         }
 

--- a/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/CalcResultProjectedProducersBuilder.cs
+++ b/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/CalcResultProjectedProducersBuilder.cs
@@ -46,7 +46,7 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
                 createSubtotal: H2ProjectedProducersBuilderUtils.CreateParentProducer,
                 sumProducerGroupTonnages: H2ProjectedProducersBuilderUtils.SumProducerGroupTonnages
             );
-            var h1ProjectedProduers = H1ProjectedProducersBuilderUtils.GetProjectedProducers(h1ReportedMaterials, h2ProjectedProduers, materials);
+            var h1ProjectedProduers = H1ProjectedProducersBuilderUtils.GetProjectedProducers(h1ReportedMaterials, h2ProjectedProducersWithSubtotals, materials);
             var h1ProjectedProducersWithSubtotals = AddSubtotals<CalcResultH1ProjectedProducer>(
                 h1ProjectedProduers,
                 createSubtotal: H1ProjectedProducersBuilderUtils.CreateParentProducer,
@@ -129,7 +129,7 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
         private static List<TSubmissionPeriodProducer> AddSubtotals<TSubmissionPeriodProducer>(
             List<TSubmissionPeriodProducer> projectedProducers,
             Func<TSubmissionPeriodProducer, TSubmissionPeriodProducer> createSubtotal,
-            Func<IEnumerable<TSubmissionPeriodProducer>, TSubmissionPeriodProducer> sumProducerGroupTonnages)
+            Func<List<TSubmissionPeriodProducer>, TSubmissionPeriodProducer> sumProducerGroupTonnages)
             where TSubmissionPeriodProducer : ICalcResultProjectedProducer
         {
             var result = new List<TSubmissionPeriodProducer>();
@@ -143,7 +143,7 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
 
                     result.AddRange(updatedGroup);
                     result.Add(
-                        sumProducerGroupTonnages(group)
+                        sumProducerGroupTonnages(group.ToList())
                     );
                 }
                 else

--- a/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/CalcResultProjectedProducersBuilder.cs
+++ b/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/CalcResultProjectedProducersBuilder.cs
@@ -52,24 +52,13 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
                 createSubtotal: H1ProjectedProducersBuilderUtils.CreateParentProducer,
                 sumProducerGroupTonnages: H1ProjectedProducersBuilderUtils.SumProducerGroupTonnages
             );
-            
-            var completeH1AndH2RamProducers = h2ProjectedProducersWithSubtotals
-                .Cast<ICalcResultProjectedProducer>()
-                .Concat(h1ProjectedProducersWithSubtotals)
-                .GroupBy(p => p.ProducerId)
-                .Where(g => g.All(p => p.ProjectedTonnageByMaterial.All(m => !m.Value.IsWithoutRamTonnage())))
-                .Select(g => g.Key)
-                .ToHashSet();
-
-            var h2ProjectedProducersFiltered = h2ProjectedProducersWithSubtotals.Where(p => !completeH1AndH2RamProducers.Contains(p.ProducerId));
-            var h1ProjectedProducersFiltered = h1ProjectedProducersWithSubtotals.Where(p => !completeH1AndH2RamProducers.Contains(p.ProducerId));
 
             return new CalcResultProjectedProducers
             {
                 H2ProjectedProducersHeaders = H2ProjectedProducersBuilderUtils.GetProjectedProducerHeaders(materials),
                 H1ProjectedProducersHeaders = H1ProjectedProducersBuilderUtils.GetProjectedProducerHeaders(materials),
-                H2ProjectedProducers = h2ProjectedProducersFiltered.OrderBy(p => p.ProducerId).ThenBy(p => p.Level).ThenBy(p => p.SubsidiaryId).ToList(),
-                H1ProjectedProducers = h1ProjectedProducersFiltered.OrderBy(p => p.ProducerId).ThenBy(p => p.Level).ThenBy(p => p.SubsidiaryId).ToList()
+                H2ProjectedProducers = h2ProjectedProducersWithSubtotals.OrderBy(p => p.ProducerId).ThenBy(p => p.Level).ThenBy(p => p.SubsidiaryId).ToList(),
+                H1ProjectedProducers = h1ProjectedProducersWithSubtotals.OrderBy(p => p.ProducerId).ThenBy(p => p.Level).ThenBy(p => p.SubsidiaryId).ToList()
             };
         }
 

--- a/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/H1ProjectedProducersBuilderUtils.cs
+++ b/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/H1ProjectedProducersBuilderUtils.cs
@@ -25,7 +25,7 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
             {
                 var prodGroup = h2ProjectedProducers.Where(p => p.ProducerId == rm.ProducerId);
                 var maybeSubtotal = prodGroup.Where(p => p.IsSubtotal); 
-                return maybeSubtotal.Any() ? maybeSubtotal.First() : prodGroup.Where(p => p.SubsidiaryId == rm.SubsidiaryId).FirstOrDefault();
+                return maybeSubtotal.Any() ? maybeSubtotal.First() : prodGroup.FirstOrDefault(p => p.SubsidiaryId == rm.SubsidiaryId);
             }
 
             return reportedMaterials.Select(rm => new CalcResultH1ProjectedProducer

--- a/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/H1ProjectedProducersBuilderUtils.cs
+++ b/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/H1ProjectedProducersBuilderUtils.cs
@@ -21,17 +21,20 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
     {
         public static List<CalcResultH1ProjectedProducer> GetProjectedProducers(List<ProducerReportedMaterialsForSubmissionPeriod> reportedMaterials, List<CalcResultH2ProjectedProducer> h2ProjectedProducers, List<MaterialDetail> materials)
         {
+            CalcResultH2ProjectedProducer? GetH2Producer(ProducerReportedMaterialsForSubmissionPeriod rm)
+            {
+                var prodGroup = h2ProjectedProducers.Where(p => p.ProducerId == rm.ProducerId);
+                var maybeSubtotal = prodGroup.Where(p => p.IsSubtotal); 
+                return maybeSubtotal.Any() ? maybeSubtotal.First() : prodGroup.Where(p => p.SubsidiaryId == rm.SubsidiaryId).FirstOrDefault();
+            }
+
             return reportedMaterials.Select(rm => new CalcResultH1ProjectedProducer
             {
                 ProducerId = rm.ProducerId,
                 SubsidiaryId = rm.SubsidiaryId,
                 Level = string.Empty, // Level will be set later when subtotals are added
                 SubmissionPeriodCode = rm.SubmissionPeriod,
-                H1ProjectedTonnageByMaterial = GetProjectedTonnages(
-                    materials,
-                    rm.ReportedMaterials,
-                    h2ProjectedProducers.FirstOrDefault(p => p.ProducerId == rm.ProducerId && p.SubsidiaryId == rm.SubsidiaryId)
-                )
+                H1ProjectedTonnageByMaterial = GetProjectedTonnages(materials, rm.ReportedMaterials, GetH2Producer(rm))
             }).ToList();
         }
 
@@ -78,7 +81,6 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
                 HouseholdDrinksContainerTonnageWithoutRAM = householdDrinksContainerTonnageWithoutRAM,
                 H2RamProportions = h2RamProportions,
                 TotalTonnage = householdRAMTonnage.Tonnage + publicBinRAMTonnage.Tonnage + (hdcRAMTonnage?.Tonnage ?? 0),
-                H2TotalTonnage = h2ProjectedTonnage.TotalTonnage,
                 ProjectedHouseholdRAMTonnage = h1ProportionateRAMTonnage(householdRAMTonnage, householdTonnageWithoutRAM, h2ProjectedTonnage.TotalTonnage),
                 ProjectedPublicBinRAMTonnage = h1ProportionateRAMTonnage(publicBinRAMTonnage, publicBinTonnageWithoutRAM, h2ProjectedTonnage.TotalTonnage),
                 ProjectedHouseholdDrinksContainerRAMTonnage = hdcRAMTonnage != null ? h1ProportionateRAMTonnage(hdcRAMTonnage, householdDrinksContainerTonnageWithoutRAM!.Value, h2ProjectedTonnage.TotalTonnage) : null
@@ -153,13 +155,8 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
                 };
         }
 
-        public static CalcResultH1ProjectedProducer SumProducerGroupTonnages(IEnumerable<CalcResultH1ProjectedProducer> prodGroup)
+        public static CalcResultH1ProjectedProducer SumProducerGroupTonnages(List<CalcResultH1ProjectedProducer> prodGroup)
         {
-            decimal GetSummedH2Proportion(string matKey, Func<CalcResultH1ProjectedProducerMaterialTonnage, decimal> proportionFunc) {
-               var totalH2Tonnage = prodGroup.Sum(p => p.H1ProjectedTonnageByMaterial[matKey].H2TotalTonnage); 
-               return totalH2Tonnage > 0 ? prodGroup.Sum(p => proportionFunc(p.H1ProjectedTonnageByMaterial[matKey]) * p.H1ProjectedTonnageByMaterial[matKey].H2TotalTonnage) / totalH2Tonnage : 0;
-            }
-
             var producer = prodGroup.First();
             var sumRam = (string matKey, Func<CalcResultProjectedProducerMaterialTonnage, RAMTonnage?> tonnageFunc) => 
                 CalcResultProjectedProducersBuilder.SumRAMTonnages(prodGroup.Cast<ICalcResultProjectedProducer>().ToList(), matKey, tonnageFunc);
@@ -180,16 +177,8 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
                         HouseholdTonnageWithoutRAM = prodGroup.Sum(p => p.H1ProjectedTonnageByMaterial[kvp.Key].HouseholdTonnageWithoutRAM),
                         PublicBinTonnageWithoutRAM = prodGroup.Sum(p => p.H1ProjectedTonnageByMaterial[kvp.Key].PublicBinTonnageWithoutRAM),
                         HouseholdDrinksContainerTonnageWithoutRAM = kvp.Key == MaterialCodes.Glass ? prodGroup.Sum(p => p.H1ProjectedTonnageByMaterial[kvp.Key].HouseholdDrinksContainerTonnageWithoutRAM ?? 0) : null,
-                        H2RamProportions = new RAMProportions {
-                            Red = GetSummedH2Proportion(kvp.Key, t => t.H2RamProportions.Red),
-                            Amber = GetSummedH2Proportion(kvp.Key, t => t.H2RamProportions.Amber),
-                            Green = GetSummedH2Proportion(kvp.Key, t => t.H2RamProportions.Green),
-                            RedMedical = GetSummedH2Proportion(kvp.Key, t => t.H2RamProportions.RedMedical),
-                            AmberMedical = GetSummedH2Proportion(kvp.Key, t => t.H2RamProportions.AmberMedical),
-                            GreenMedical = GetSummedH2Proportion(kvp.Key, t => t.H2RamProportions.GreenMedical),
-                        },
+                        H2RamProportions = producer.H1ProjectedTonnageByMaterial[kvp.Key].H2RamProportions ?? new RAMProportions(),
                         TotalTonnage = prodGroup.Sum(p => p.H1ProjectedTonnageByMaterial[kvp.Key].TotalTonnage),
-                        H2TotalTonnage = prodGroup.Sum(p => p.H1ProjectedTonnageByMaterial[kvp.Key].H2TotalTonnage),
                         ProjectedHouseholdRAMTonnage = sumRam(kvp.Key, p => p.ProjectedHouseholdRAMTonnage),
                         ProjectedPublicBinRAMTonnage = sumRam(kvp.Key, p => p.ProjectedPublicBinRAMTonnage),
                         ProjectedHouseholdDrinksContainerRAMTonnage = kvp.Key == MaterialCodes.Glass ? sumRam(kvp.Key, p => p.ProjectedHouseholdDrinksContainerRAMTonnage) : null
@@ -212,7 +201,6 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
                     RedMedical = 0, AmberMedical = 0, GreenMedical = 0
                 },   
                 TotalTonnage = 0,
-                H2TotalTonnage = 0,
                 ProjectedHouseholdRAMTonnage = new RAMTonnage { Tonnage = 0, RedTonnage = 0, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
                 ProjectedPublicBinRAMTonnage = new RAMTonnage { Tonnage = 0, RedTonnage = 0, AmberTonnage = 0, GreenTonnage = 0, RedMedicalTonnage = 0, AmberMedicalTonnage = 0, GreenMedicalTonnage = 0 },
                 ProjectedHouseholdDrinksContainerRAMTonnage = materialCode == MaterialCodes.Glass ? 

--- a/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/H2ProjectedProducersBuilderUtils.cs
+++ b/src/EPR.Calculator.Service.Function/Builder/ProjectedProducers/H2ProjectedProducersBuilderUtils.cs
@@ -87,7 +87,7 @@ namespace EPR.Calculator.Service.Function.Builder.ProjectedProducers
             };
         }
 
-        public static CalcResultH2ProjectedProducer SumProducerGroupTonnages(IEnumerable<CalcResultH2ProjectedProducer> prodGroup)
+        public static CalcResultH2ProjectedProducer SumProducerGroupTonnages(List<CalcResultH2ProjectedProducer> prodGroup)
         {
             var producer = prodGroup.First();
             var sumRam = (string matKey, Func<CalcResultProjectedProducerMaterialTonnage, RAMTonnage?> tonnageFunc) => 

--- a/src/EPR.Calculator.Service.Function/Exporter/CsvExporter/ProjectedProducers/CalcResultProjectedProducersExporter.cs
+++ b/src/EPR.Calculator.Service.Function/Exporter/CsvExporter/ProjectedProducers/CalcResultProjectedProducersExporter.cs
@@ -8,12 +8,23 @@ using EPR.Calculator.Service.Function.Models;
 
 namespace EPR.Calculator.Service.Function.Exporter.CsvExporter.ProjectedProducers
 {
-    
-
     public class CalcResultProjectedProducersExporter : ICalcResultProjectedProducersExporter
     {
         public void Export(CalcResultProjectedProducers calcResultProjectedProducers, StringBuilder stringBuilder)
         {
+            var allH2 = calcResultProjectedProducers.H2ProjectedProducers ?? new List<CalcResultH2ProjectedProducer>();
+            var allH1 = calcResultProjectedProducers.H1ProjectedProducers ?? new List<CalcResultH1ProjectedProducer>();
+            var completeH1AndH2RamProducers = allH2
+                .Cast<ICalcResultProjectedProducer>()
+                .Concat(allH1)
+                .GroupBy(p => p.ProducerId)
+                .Where(g => g.All(p => p.ProjectedTonnageByMaterial.All(m => !m.Value.IsWithoutRamTonnage())))
+                .Select(g => g.Key)
+                .ToHashSet();
+
+            var h2WhereModified = allH2.Where(p => !completeH1AndH2RamProducers.Contains(p.ProducerId)).ToList();
+            var h1WhereModified = allH1.Where(p => !completeH1AndH2RamProducers.Contains(p.ProducerId)).ToList();
+
             // Add empty lines
             stringBuilder.AppendLine();
             stringBuilder.AppendLine();
@@ -22,9 +33,9 @@ namespace EPR.Calculator.Service.Function.Exporter.CsvExporter.ProjectedProducer
             PrepareProjectedProducersHeaders(calcResultProjectedProducers.H2ProjectedProducersHeaders!, stringBuilder);
 
             // Add H2 data
-            if (calcResultProjectedProducers.H2ProjectedProducers?.Any() == true)
+            if (h2WhereModified.Any() == true)
             {
-                H2ProjectedProducersExporterUtils.AppendProjectedProducers(calcResultProjectedProducers.H2ProjectedProducers!, stringBuilder);
+                H2ProjectedProducersExporterUtils.AppendProjectedProducers(h2WhereModified, stringBuilder);
             }
             else
             {
@@ -39,9 +50,9 @@ namespace EPR.Calculator.Service.Function.Exporter.CsvExporter.ProjectedProducer
             PrepareProjectedProducersHeaders(calcResultProjectedProducers.H1ProjectedProducersHeaders!, stringBuilder);
 
             // Add H1 data
-            if (calcResultProjectedProducers.H1ProjectedProducers?.Any() == true)
+            if (h1WhereModified.Any() == true)
             {
-                H1ProjectedProducersExporterUtils.AppendProjectedProducers(calcResultProjectedProducers.H1ProjectedProducers!, stringBuilder);
+                H1ProjectedProducersExporterUtils.AppendProjectedProducers(h1WhereModified, stringBuilder);
             }
             else
             {
@@ -52,14 +63,14 @@ namespace EPR.Calculator.Service.Function.Exporter.CsvExporter.ProjectedProducer
         private void PrepareProjectedProducersHeaders(ProjectedProducersHeaders headers, StringBuilder csvContent)
         {
             // Add projected producers headers
-            csvContent.AppendLine(CsvSanitiser.SanitiseData(headers.TitleHeader!.Name));
+            csvContent.AppendLine(CsvSanitiser.SanitiseData(headers.TitleHeader.Name));
             csvContent.AppendLine();
 
             // Add material breakdown headers
-            WriteProjectedProducersSecondaryHeaders(headers.MaterialBreakdownHeaders!, csvContent);
+            WriteProjectedProducersSecondaryHeaders(headers.MaterialBreakdownHeaders, csvContent);
 
             // Add column headers
-            WriteProjectedProducersColumnHeaders(headers.ColumnHeaders!, csvContent);
+            WriteProjectedProducersColumnHeaders(headers.ColumnHeaders, csvContent);
             csvContent.AppendLine();
         }
 

--- a/src/EPR.Calculator.Service.Function/Exporter/CsvExporter/ProjectedProducers/H1ProjectedProducersExporterUtils.cs
+++ b/src/EPR.Calculator.Service.Function/Exporter/CsvExporter/ProjectedProducers/H1ProjectedProducersExporterUtils.cs
@@ -36,9 +36,7 @@ namespace EPR.Calculator.Service.Function.Exporter.CsvExporter.ProjectedProducer
         private static void AppendMaterialTonnage(StringBuilder csvContent, string materialCode, CalcResultH1ProjectedProducerMaterialTonnage tonnage)
         {
             string GetProportionPercentage(decimal proportion) {
-                var showProportion = 
-                    (tonnage.HouseholdTonnageWithoutRAM > 0 || tonnage.PublicBinTonnageWithoutRAM > 0 || (tonnage.HouseholdDrinksContainerTonnageWithoutRAM ?? 0) > 0)
-                        && tonnage.H2RamProportions.AnyProportions();
+                var showProportion = tonnage.IsWithoutRamTonnage() && tonnage.H2RamProportions.AnyProportions();
                 return showProportion ? CsvSanitiser.SanitiseData(proportion * 100, DecimalPlaces.Two, DecimalFormats.F2, isPercentage: true) : CsvSanitiser.SanitiseData(CommonConstants.Hyphen);
             }
 

--- a/src/EPR.Calculator.Service.Function/Exporter/CsvExporter/ProjectedProducers/H1ProjectedProducersExporterUtils.cs
+++ b/src/EPR.Calculator.Service.Function/Exporter/CsvExporter/ProjectedProducers/H1ProjectedProducersExporterUtils.cs
@@ -38,7 +38,7 @@ namespace EPR.Calculator.Service.Function.Exporter.CsvExporter.ProjectedProducer
             string GetProportionPercentage(decimal proportion) {
                 var showProportion = 
                     (tonnage.HouseholdTonnageWithoutRAM > 0 || tonnage.PublicBinTonnageWithoutRAM > 0 || (tonnage.HouseholdDrinksContainerTonnageWithoutRAM ?? 0) > 0)
-                        && tonnage.H2TotalTonnage > 0;
+                        && tonnage.H2RamProportions.AnyProportions();
                 return showProportion ? CsvSanitiser.SanitiseData(proportion * 100, DecimalPlaces.Two, DecimalFormats.F2, isPercentage: true) : CsvSanitiser.SanitiseData(CommonConstants.Hyphen);
             }
 

--- a/src/EPR.Calculator.Service.Function/Models/CalcResultProjectedProducerTonnage.cs
+++ b/src/EPR.Calculator.Service.Function/Models/CalcResultProjectedProducerTonnage.cs
@@ -24,6 +24,11 @@
         public decimal RedMedical { get; init; }
         public decimal AmberMedical { get; init; }
         public decimal GreenMedical { get; init; }
+
+        public bool AnyProportions()
+        {
+            return Red > 0 || Amber > 0 || Green > 0 || RedMedical > 0 || AmberMedical > 0 || GreenMedical > 0;
+        }
     }
 
     public abstract record CalcResultProjectedProducerMaterialTonnage
@@ -57,6 +62,5 @@
     public record CalcResultH1ProjectedProducerMaterialTonnage : CalcResultProjectedProducerMaterialTonnage
     {
         public required RAMProportions H2RamProportions { get; init; }
-        public required decimal H2TotalTonnage { get; init; }
     }
 }

--- a/src/EPR.Calculator.Service.Function/Models/CalcResultProjectedProducerTonnage.cs
+++ b/src/EPR.Calculator.Service.Function/Models/CalcResultProjectedProducerTonnage.cs
@@ -55,6 +55,11 @@
         public decimal GetTotalProjectedRedMedicalTonnage() { return GetTotalProjectedRamTonnage(t => t.RedMedicalTonnage); }
         public decimal GetTotalProjectedAmberMedicalTonnage() { return GetTotalProjectedRamTonnage(t => t.AmberMedicalTonnage); }
         public decimal GetTotalProjectedGreenMedicalTonnage() { return GetTotalProjectedRamTonnage(t => t.GreenMedicalTonnage); }
+
+        public bool IsWithoutRamTonnage()
+        {
+            return HouseholdTonnageWithoutRAM > 0 || PublicBinTonnageWithoutRAM > 0 || (HouseholdDrinksContainerTonnageWithoutRAM ?? 0) > 0;
+        }
     }
 
     public record CalcResultH2ProjectedProducerMaterialTonnage : CalcResultProjectedProducerMaterialTonnage {}


### PR DESCRIPTION
- For holding groups, use the level 1 (subtotal) H2 modulation factor to calculate level 2 projections.
- Filter out complete ram-assigned H1/H2 projected producers.